### PR TITLE
DM-38304: Fix crash in `load-tap --dry-run` command

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,6 +109,17 @@ class CliTestCase(unittest.TestCase):
         result = runner.invoke(cli, ["load-tap", f"--engine-url={url}", TEST_YAML], catch_exceptions=False)
         self.assertEqual(result.exit_code, 0)
 
+    def test_load_tap_mock(self) -> None:
+        """Test for load-tap --dry-run command"""
+
+        url = "postgresql+psycopg2://"
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["load-tap", f"--engine-url={url}", "--dry-run", TEST_YAML], catch_exceptions=False
+        )
+        self.assertEqual(result.exit_code, 0)
+
     def test_modify_tap(self) -> None:
         """Test for modify-tap command"""
 


### PR DESCRIPTION
`create_mock_engine` does not actually return an Engine, but a MockConnection instance which has very different API. Updated TapLoadingVisitor to handle their differences correctly. Added unit test for `load-tap --dry-run`.