### PR TITLE
DM-41688: Add Pydantic data model to felis

### DIFF
--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -150,12 +150,12 @@ def load_tap(
         schema_obj = {"@context": DEFAULT_CONTEXT, "@graph": top_level_object}
     else:
         logger.error("Schema object not of recognizable type")
-        sys.exit(1)
+        raise click.exceptions.Exit(1)
 
     normalized = _normalize(schema_obj, embed="@always")
     if len(normalized["@graph"]) > 1 and (schema_name or catalog_name):
         logger.error("--schema-name and --catalog-name incompatible with multiple schemas")
-        sys.exit(1)
+        raise click.exceptions.Exit(1)
 
     # Force normalized["@graph"] to a list, which is what happens when there's
     # multiple schemas

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -1,0 +1,356 @@
+# This file is part of felis.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+from collections.abc import Mapping
+from enum import Enum
+from typing import Any, Literal
+
+from astropy import units as units  # type: ignore
+from astropy.io.votable import ucd  # type: ignore
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+logger = logging.getLogger(__name__)
+# logger.setLevel(logging.DEBUG)
+
+
+class BaseObject(BaseModel):
+    """Base class for all Felis objects."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid", use_enum_values=True)
+    """Configuration for the `BaseModel` class.
+
+    Allow attributes to be populated by name and forbid extra attributes.
+    """
+
+    name: str
+    """The name of the database object.
+
+    All Felis database objects must have a name.
+    """
+
+    id: str = Field(alias="@id")
+    """The unique identifier of the database object.
+
+    All Felis database objects must have a unique identifier.
+    """
+
+    description: str | None = None
+    """A description of the database object.
+
+    The description is optional.
+    """
+
+
+class DataType(Enum):
+    """`Enum` representing the data types supported by Felis."""
+
+    BOOLEAN = "boolean"
+    BYTE = "byte"
+    SHORT = "short"
+    INT = "int"
+    LONG = "long"
+    FLOAT = "float"
+    DOUBLE = "double"
+    CHAR = "char"
+    STRING = "string"
+    UNICODE = "unicode"
+    TEXT = "text"
+    BINARY = "binary"
+    TIMESTAMP = "timestamp"
+
+
+class Column(BaseObject):
+    """A column in a table."""
+
+    datatype: DataType
+    """The datatype of the column."""
+
+    length: int | None = None
+    """The length of the column."""
+
+    nullable: bool = True
+    """Whether the column can be `NULL`."""
+
+    value: Any = None
+    """The default value of the column."""
+
+    autoincrement: bool | None = None
+    """Whether the column is autoincremented."""
+
+    mysql_datatype: str | None = Field(None, alias="mysql:datatype")
+    """The MySQL datatype of the column."""
+
+    ivoa_ucd: str | None = Field(None, alias="ivoa:ucd")
+    """The IVOA UCD of the column."""
+
+    fits_tunit: str | None = Field(None, alias="fits:tunit")
+    """The FITS TUNIT of the column."""
+
+    ivoa_unit: str | None = Field(None, alias="ivoa:unit")
+    """The IVOA unit of the column."""
+
+    tap_column_index: int | None = Field(None, alias="tap:column_index")
+    """The TAP_SCHEMA column index of the column."""
+
+    tap_principal: int | None = Field(0, alias="tap:principal", ge=0, le=1)
+    """Whether this is a TAP_SCHEMA principal column; can be either 0 or 1.
+
+    This could be a boolean instead of 0 or 1.
+    """
+
+    votable_arraysize: int | Literal["*"] | None = Field(None, alias="votable:arraysize")
+    """The VOTable arraysize of the column."""
+
+    tap_std: int | None = Field(0, alias="tap:std", ge=0, le=1)
+    """TAP_SCHEMA indication that this column is defined by an IVOA standard.
+    """
+
+    votable_utype: str | None = Field(None, alias="votable:utype")
+    """The VOTable utype (usage-specific or unique type) of the column."""
+
+    votable_xtype: str | None = Field(None, alias="votable:xtype")
+    """The VOTable xtype (extended type) of the column."""
+
+    @field_validator("ivoa_ucd")
+    @classmethod
+    def check_ivoa_ucd(cls, ivoa_ucd: str) -> str:
+        """Check that IVOA UCD values are valid."""
+        if ivoa_ucd is not None:
+            try:
+                ucd.parse_ucd(ivoa_ucd, check_controlled_vocabulary=True, has_colon=";" in ivoa_ucd)
+            except ValueError as e:
+                raise ValueError(f"Invalid IVOA UCD: {e}")
+        return ivoa_ucd
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_units(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Check that units are valid."""
+        fits_unit = values.get("fits:tunit")
+        ivoa_unit = values.get("ivoa:unit")
+
+        if fits_unit and ivoa_unit:
+            raise ValueError("Column cannot have both FITS and IVOA units")
+        unit = fits_unit or ivoa_unit
+
+        if unit is not None:
+            try:
+                units.Unit(unit)
+            except ValueError as e:
+                raise ValueError(f"Invalid unit: {e}")
+
+        return values
+
+
+class Constraint(BaseObject):
+    """A database table constraint."""
+
+    deferrable: bool = False
+    """If `True` then this constraint will be declared as deferrable."""
+
+    initially: str | None = None
+    """Value for ``INITIALLY`` clause, only used if ``deferrable`` is True."""
+
+    annotations: Mapping[str, Any] = Field(default_factory=dict)
+    """Additional annotations for this constraint."""
+
+    type: str | None = Field(None, alias="@type")
+    """The type of the constraint."""
+
+
+class CheckConstraint(Constraint):
+    """A check constraint on a table."""
+
+    expression: str
+    """The expression for the check constraint."""
+
+
+class UniqueConstraint(Constraint):
+    """A unique constraint on a table."""
+
+    columns: list[str]
+    """The columns in the unique constraint."""
+
+
+class Index(BaseObject):
+    """A database table index.
+
+    An index can be defined on either columns or expressions, but not both.
+    """
+
+    columns: list[str] | None = None
+    """The columns in the index."""
+
+    expressions: list[str] | None = None
+    """The expressions in the index."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def check_columns_or_expressions(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Check that columns or expressions are specified, but not both."""
+        if "columns" in values and "expressions" in values:
+            raise ValueError("Defining columns and expressions is not valid")
+        elif "columns" not in values and "expressions" not in values:
+            raise ValueError("Must define columns or expressions")
+        return values
+
+
+class ForeignKeyConstraint(Constraint):
+    """A foreign key constraint on a table.
+
+    These will be reflected in the TAP_SCHEMA keys and key_columns data.
+    """
+
+    columns: list[str]
+    """The columns comprising the foreign key."""
+
+    referenced_columns: list[str] = Field(alias="referencedColumns")
+    """The columns referenced by the foreign key."""
+
+
+class Table(BaseObject):
+    """A database table."""
+
+    columns: list[Column]
+    """The columns in the table."""
+
+    constraints: list[Constraint] = Field(default_factory=list)
+    """The constraints on the table."""
+
+    indexes: list[Index] = Field(default_factory=list)
+    """The indexes on the table."""
+
+    primaryKey: str | list[str] | None = None
+    """The primary key of the table."""
+
+    tap_table_index: int | None = Field(None, alias="tap:table_index")
+    """The IVOA TAP_SCHEMA table index of the table."""
+
+    mysql_engine: str | None = Field(None, alias="mysql:engine")
+    """The mysql engine to use for the table.
+
+    For now this is a freeform string but it could be constrained to a list of
+    known engines in the future.
+    """
+
+    mysql_charset: str | None = Field(None, alias="mysql:charset")
+    """The mysql charset to use for the table.
+
+    For now this is a freeform string but it could be constrained to a list of
+    known charsets in the future.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def create_constraints(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Create constraints from the ``constraints`` field."""
+        if "constraints" in values:
+            new_constraints: list[Constraint] = []
+            for item in values["constraints"]:
+                if item["@type"] == "ForeignKey":
+                    new_constraints.append(ForeignKeyConstraint(**item))
+                elif item["@type"] == "Unique":
+                    new_constraints.append(UniqueConstraint(**item))
+                elif item["@type"] == "Check":
+                    new_constraints.append(CheckConstraint(**item))
+                else:
+                    raise ValueError(f"Unknown constraint type: {item['@type']}")
+            values["constraints"] = new_constraints
+        return values
+
+    @field_validator("columns", mode="after")
+    @classmethod
+    def check_unique_column_names(cls, columns: list[Column]) -> list[Column]:
+        """Check that column names are unique."""
+        if len(columns) != len(set(column.name for column in columns)):
+            raise ValueError("Column names must be unique")
+        return columns
+
+
+class SchemaVersion(BaseModel):
+    """The version of the schema."""
+
+    current: str
+    """The current version of the schema."""
+
+    compatible: list[str] | None = None
+    """The compatible versions of the schema."""
+
+    read_compatible: list[str] | None = None
+    """The read compatible versions of the schema."""
+
+
+def _extract_ids(
+    obj: BaseModel | list[BaseModel] | dict[str, BaseModel], id_map: dict[str, BaseModel], processed: set[int]
+) -> None:
+    """Recursively extract ID values from a `BaseModel` object
+    and map them to their corresponding object.
+    """
+    obj_id = id(obj)
+    if obj_id in processed:
+        return
+    processed.add(obj_id)
+
+    if isinstance(obj, BaseModel):
+        if hasattr(obj, "id"):
+            id_map[getattr(obj, "id")] = obj
+
+        # Iterate over the fields of the BaseModel object
+        for attr, value in obj.__dict__.items():
+            if isinstance(value, BaseModel | list | dict):
+                _extract_ids(value, id_map, processed)
+
+    elif isinstance(obj, list):
+        for item in obj:
+            _extract_ids(item, id_map, processed)
+
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            _extract_ids(value, id_map, processed)
+
+
+class Schema(BaseObject):
+    """The database schema."""
+
+    version: SchemaVersion | None = None
+    """The version of the schema."""
+
+    tables: list[Table]
+    """The tables in the schema."""
+
+    id_map: dict[str, Any] = Field(default_factory=dict, exclude=True)
+    """Map of IDs to objects."""
+
+    @field_validator("tables", mode="after")
+    @classmethod
+    def check_unique_table_names(cls, tables: list[Table]) -> list[Table]:
+        """Check that table names are unique."""
+        if len(tables) != len(set(table.name for table in tables)):
+            raise ValueError("Table names must be unique")
+        return tables
+
+    @model_validator(mode="after")
+    def create_id_map(self) -> "Schema":
+        """Create a map of IDs to objects."""
+        _extract_ids(self, self.id_map, set())
+        logger.debug(f"ID map contains {len(self.id_map.keys())} objects")
+        return self

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sqlalchemy >= 1.4
 click
 pyyaml
 pyld
+pydantic >= 2, < 3

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1,0 +1,355 @@
+# This file is part of felis.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+import yaml
+from pydantic import ValidationError
+
+from felis.datamodel import (
+    CheckConstraint,
+    Column,
+    DataType,
+    ForeignKeyConstraint,
+    Index,
+    Schema,
+    SchemaVersion,
+    Table,
+    UniqueConstraint,
+)
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+TEST_YAML = os.path.join(TESTDIR, "data", "test.yml")
+
+
+class DataModelTestCase(unittest.TestCase):
+    """Test validation a test schema from a YAML file."""
+
+    schema_obj: Schema
+
+    def test_validation(self) -> None:
+        """Load test file and validate it using the data model."""
+        with open(TEST_YAML) as test_yaml:
+            data = yaml.safe_load(test_yaml)
+            self.schema_obj = Schema.model_validate(data)
+
+
+class ColumnTestCase(unittest.TestCase):
+    """Test the `Column` class."""
+
+    def test_validation(self) -> None:
+        """Test validation of the `Column` class."""
+        # Default initialization should throw an exception.
+        with self.assertRaises(ValidationError):
+            Column()
+
+        # Setting only name should throw an exception.
+        with self.assertRaises(ValidationError):
+            Column(name="testColumn")
+
+        # Setting name and id should throw an exception from missing datatype.
+        with self.assertRaises(ValidationError):
+            Column(name="testColumn", id="#test_id")
+
+        # Setting name, id, and datatype should not throw an exception and
+        # should load data correctly.
+        col = Column(name="testColumn", id="#test_id", datatype="string")
+        self.assertEqual(col.name, "testColumn", "name should be 'testColumn'")
+        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(col.datatype, DataType.STRING.value, "datatype should be 'DataType.STRING'")
+
+        # Creating from data dictionary should work and load data correctly.
+        data = {"name": "testColumn", "id": "#test_id", "datatype": "string"}
+        col = Column(**data)
+        self.assertEqual(col.name, "testColumn", "name should be 'testColumn'")
+        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(col.datatype, DataType.STRING.value, "datatype should be 'DataType.STRING'")
+
+        # Setting a bad IVOA UCD should throw an error.
+        with self.assertRaises(ValidationError):
+            Column(**data, ivoa_ucd="bad")
+
+        # Setting a valid IVOA UCD should not throw an error.
+        col = Column(**data, ivoa_ucd="meta.id")
+        self.assertEqual(col.ivoa_ucd, "meta.id", "ivoa_ucd should be 'meta.id'")
+
+        units_data = data.copy()
+
+        # Setting a bad IVOA unit should throw an error.
+        units_data["ivoa:unit"] = "bad"
+        with self.assertRaises(ValidationError):
+            Column(**units_data)
+
+        # Setting a valid IVOA unit should not throw an error.
+        units_data["ivoa:unit"] = "m"
+        col = Column(**units_data)
+        self.assertEqual(col.ivoa_unit, "m", "ivoa_unit should be 'm'")
+
+        units_data = data.copy()
+
+        # Setting a bad FITS TUNIT should throw an error.
+        units_data["fits:tunit"] = "bad"
+        with self.assertRaises(ValidationError):
+            Column(**units_data)
+
+        # Setting a valid FITS TUNIT should not throw an error.
+        units_data["fits:tunit"] = "m"
+        col = Column(**units_data)
+        self.assertEqual(col.fits_tunit, "m", "fits_tunit should be 'm'")
+
+        # Setting both IVOA unit and FITS TUNIT should throw an error.
+        units_data["ivoa:unit"] = "m"
+        with self.assertRaises(ValidationError):
+            Column(**units_data)
+
+
+class ConstraintTestCase(unittest.TestCase):
+    """Test the `UniqueConstraint`, `Index`, `CheckCosntraint`, and
+    `ForeignKeyConstraint` classes.
+    """
+
+    def test_unique_constraint_validation(self) -> None:
+        """Test validation of the `UniqueConstraint` class."""
+        # Default initialization should throw an exception.
+        with self.assertRaises(ValidationError):
+            UniqueConstraint()
+
+        # Setting only name should throw an exception.
+        with self.assertRaises(ValidationError):
+            UniqueConstraint(name="testConstraint")
+
+        # Setting name and id should throw an exception from missing columns.
+        with self.assertRaises(ValidationError):
+            UniqueConstraint(name="testConstraint", id="#test_id")
+
+        # Setting name, id, and columns should not throw an exception and
+        # should load data correctly.
+        col = UniqueConstraint(name="testConstraint", id="#test_id", columns=["testColumn"])
+        self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
+        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(col.columns, ["testColumn"], "columns should be ['testColumn']")
+
+        # Creating from data dictionary should work and load data correctly.
+        data = {"name": "testConstraint", "id": "#test_id", "columns": ["testColumn"]}
+        col = UniqueConstraint(**data)
+        self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
+        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(col.columns, ["testColumn"], "columns should be ['testColumn']")
+
+    def test_index_validation(self) -> None:
+        """Test validation of the `Index` class."""
+        # Default initialization should throw an exception.
+        with self.assertRaises(ValidationError):
+            Index()
+
+        # Setting only name should throw an exception.
+        with self.assertRaises(ValidationError):
+            Index(name="testConstraint")
+
+        # Setting name and id should throw an exception from missing columns.
+        with self.assertRaises(ValidationError):
+            Index(name="testConstraint", id="#test_id")
+
+        # Setting name, id, and columns should not throw an exception and
+        # should load data correctly.
+        col = Index(name="testConstraint", id="#test_id", columns=["testColumn"])
+        self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
+        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(col.columns, ["testColumn"], "columns should be ['testColumn']")
+
+        # Creating from data dictionary should work and load data correctly.
+        data = {"name": "testConstraint", "id": "#test_id", "columns": ["testColumn"]}
+        col = Index(**data)
+        self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
+        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(col.columns, ["testColumn"], "columns should be ['testColumn']")
+
+        # Setting both columns and expressions on an index should throw an
+        # exception.
+        with self.assertRaises(ValidationError):
+            Index(name="testConstraint", id="#test_id", columns=["testColumn"], expressions=["1+2"])
+
+    def test_foreign_key_validation(self) -> None:
+        """Test validation of the `ForeignKeyConstraint` class."""
+        # Default initialization should throw an exception.
+        with self.assertRaises(ValidationError):
+            ForeignKeyConstraint()
+
+        # Setting only name should throw an exception.
+        with self.assertRaises(ValidationError):
+            ForeignKeyConstraint(name="testConstraint")
+
+        # Setting name and id should throw an exception from missing columns.
+        with self.assertRaises(ValidationError):
+            ForeignKeyConstraint(name="testConstraint", id="#test_id")
+
+        # Setting name, id, and columns should not throw an exception and
+        # should load data correctly.
+        col = ForeignKeyConstraint(
+            name="testConstraint", id="#test_id", columns=["testColumn"], referenced_columns=["testColumn"]
+        )
+        self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
+        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(col.columns, ["testColumn"], "columns should be ['testColumn']")
+        self.assertEqual(
+            col.referenced_columns, ["testColumn"], "referenced_columns should be ['testColumn']"
+        )
+
+        # Creating from data dictionary should work and load data correctly.
+        data = {
+            "name": "testConstraint",
+            "id": "#test_id",
+            "columns": ["testColumn"],
+            "referenced_columns": ["testColumn"],
+        }
+        col = ForeignKeyConstraint(**data)
+        self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
+        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(col.columns, ["testColumn"], "columns should be ['testColumn']")
+        self.assertEqual(
+            col.referenced_columns, ["testColumn"], "referenced_columns should be ['testColumn']"
+        )
+
+    def test_check_constraint_validation(self) -> None:
+        """Check validation of the `CheckConstraint` class."""
+        # Default initialization should throw an exception.
+        with self.assertRaises(ValidationError):
+            CheckConstraint()
+
+        # Setting only name should throw an exception.
+        with self.assertRaises(ValidationError):
+            CheckConstraint(name="testConstraint")
+
+        # Setting name and id should throw an exception from missing
+        # expression.
+        with self.assertRaises(ValidationError):
+            CheckConstraint(name="testConstraint", id="#test_id")
+
+        # Setting name, id, and expression should not throw an exception and
+        # should load data correctly.
+        col = CheckConstraint(name="testConstraint", id="#test_id", expression="1+2")
+        self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
+        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(col.expression, "1+2", "expression should be '1+2'")
+
+        # Creating from data dictionary should work and load data correctly.
+        data = {
+            "name": "testConstraint",
+            "id": "#test_id",
+            "expression": "1+2",
+        }
+        col = CheckConstraint(**data)
+        self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
+        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(col.expression, "1+2", "expression should be '1+2'")
+
+
+class TableTestCase(unittest.TestCase):
+    """Test the `Table` class."""
+
+    def test_validation(self) -> None:
+        # Default initialization should throw an exception.
+        with self.assertRaises(ValidationError):
+            Table()
+
+        # Setting only name should throw an exception.
+        with self.assertRaises(ValidationError):
+            Table(name="testTable")
+
+        # Setting name and id should throw an exception from missing columns.
+        with self.assertRaises(ValidationError):
+            Index(name="testTable", id="#test_id")
+
+        testCol = Column(name="testColumn", id="#test_id", datatype="string")
+
+        # Setting name, id, and columns should not throw an exception and
+        # should load data correctly.
+        tbl = Table(name="testTable", id="#test_id", columns=[testCol])
+        self.assertEqual(tbl.name, "testTable", "name should be 'testTable'")
+        self.assertEqual(tbl.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(tbl.columns, [testCol], "columns should be ['testColumn']")
+
+        # Creating a table with duplicate column names should raise an
+        # exception.
+        with self.assertRaises(ValidationError):
+            Table(name="testTable", id="#test_id", columns=[testCol, testCol])
+
+
+class SchemaTestCase(unittest.TestCase):
+    """Test the `Schema` class."""
+
+    def test_validation(self) -> None:
+        # Default initialization should throw an exception.
+        with self.assertRaises(ValidationError):
+            Schema()
+
+        # Setting only name should throw an exception.
+        with self.assertRaises(ValidationError):
+            Schema(name="testSchema")
+
+        # Setting name and id should throw an exception from missing columns.
+        with self.assertRaises(ValidationError):
+            Schema(name="testSchema", id="#test_id")
+
+        test_col = Column(name="testColumn", id="#test_id", datatype="string")
+        test_tbl = Table(name="testTable", id="#test_id", columns=[test_col])
+
+        # Setting name, id, and columns should not throw an exception and
+        # should load data correctly.
+        sch = Schema(name="testSchema", id="#test_id", tables=[test_tbl])
+        self.assertEqual(sch.name, "testSchema", "name should be 'testSchema'")
+        self.assertEqual(sch.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(sch.tables, [test_tbl], "tables should be ['testTable']")
+
+        # Creating a schema with duplicate table names should raise an
+        # exception.
+        with self.assertRaises(ValidationError):
+            Schema(name="testSchema", id="#test_id", tables=[test_tbl, test_tbl])
+
+    def test_id_map(self) -> None:
+        """Test that the id_map is properly populated."""
+        test_col = Column(name="testColumn", id="#test_col_id", datatype="string")
+        test_tbl = Table(name="testTable", id="#test_table_id", columns=[test_col])
+        sch = Schema(name="testSchema", id="#test_schema_id", tables=[test_tbl])
+
+        # print(f"id map:\n {sch.id_map}")
+
+        for id in ["#test_col_id", "#test_table_id", "#test_schema_id"]:
+            self.assertTrue(id in sch.id_map, f"ID {id} is missing from id_map")
+
+
+class SchemaVersionTest(unittest.TestCase):
+    """Test the `SchemaVersion` class."""
+
+    def test_validation(self) -> None:
+        # Default initialization should throw an exception.
+        with self.assertRaises(ValidationError):
+            SchemaVersion()
+
+        # Setting current should not throw an exception and should load data
+        # correctly.
+        sv = SchemaVersion(current="1.0.0")
+        self.assertEqual(sv.current, "1.0.0", "current should be '1.0.0'")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a Pydantic v2 data model to felis describing the YAML schema format, as well as unit tests for the new module. A `validate` command was added to the CLI which will load any number of YAML files into Pydantic and print validation errors. This has been tested on all of the schemas in `sdm_schemas/yml`.

To run tests covering the new module:

```
cd tests && python -m unittest test_datamodel
```

To run validation on all of the SDM schemas using the CLI tool:

```
# Change to use your sdm_schemas location
felis validate ../sdm_schemas/yml/*.yaml
```

These changes make no attempt to replace usage of the existing "simple" model that is used throughout Felis. All existing functionality should be unaffected.

For more details, please see the message on this PR's single commit. Updates to the Felis documentation will be forthcoming.