### PR TITLE
DM-41890: Fix referencing problem with foreign key objects

### DIFF
--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -224,7 +224,7 @@ def modify_tap(start_schema_at: int, files: Iterable[io.TextIOBase]) -> None:
         schema_obj["tap:schema_index"] = schema_index
         graph.extend(jsonld.flatten(schema_obj))
     merged = {"@context": DEFAULT_CONTEXT, "@graph": graph}
-    normalized = _normalize(merged)
+    normalized = _normalize(merged, embed="@always")
     _dump(normalized)
 
 
@@ -266,7 +266,7 @@ def normalize(file: io.TextIOBase) -> None:
     # Force Context and Schema Type
     schema_obj["@context"] = DEFAULT_CONTEXT
     expanded = jsonld.expand(schema_obj)
-    normalized = _normalize(expanded)
+    normalized = _normalize(expanded, embed="@always")
     _dump(normalized)
 
 
@@ -295,7 +295,7 @@ def merge(files: Iterable[io.TextIOBase]) -> None:
         item_to_update.update(item)
         updated_map[_id] = item_to_update
     merged = {"@context": DEFAULT_CONTEXT, "@graph": list(updated_map.values())}
-    normalized = _normalize(merged)
+    normalized = _normalize(merged, embed="@always")
     _dump(normalized)
 
 
@@ -341,7 +341,7 @@ def _dump(obj: Mapping[str, Any]) -> None:
     print(yaml.dump(obj, Dumper=OrderedDumper, default_flow_style=False))
 
 
-def _normalize(schema_obj: Mapping[str, Any], embed="@last") -> MutableMapping[str, Any]:
+def _normalize(schema_obj: Mapping[str, Any], embed: str = "@last") -> MutableMapping[str, Any]:
     framed = jsonld.frame(schema_obj, DEFAULT_FRAME, options=dict(embed=embed))
     compacted = jsonld.compact(framed, DEFAULT_CONTEXT, options=dict(graph=True))
     graph = compacted["@graph"]

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -150,7 +150,7 @@ def load_tap(
         logger.error("Schema object not of recognizable type")
         sys.exit(1)
 
-    normalized = _normalize(schema_obj)
+    normalized = _normalize(schema_obj, embed="@always")
     if len(normalized["@graph"]) > 1 and (schema_name or catalog_name):
         logger.error("--schema-name and --catalog-name incompatible with multiple schemas")
         sys.exit(1)
@@ -341,8 +341,8 @@ def _dump(obj: Mapping[str, Any]) -> None:
     print(yaml.dump(obj, Dumper=OrderedDumper, default_flow_style=False))
 
 
-def _normalize(schema_obj: Mapping[str, Any]) -> MutableMapping[str, Any]:
-    framed = jsonld.frame(schema_obj, DEFAULT_FRAME)
+def _normalize(schema_obj: Mapping[str, Any], embed="@last") -> MutableMapping[str, Any]:
+    framed = jsonld.frame(schema_obj, DEFAULT_FRAME, options=dict(embed=embed))
     compacted = jsonld.compact(framed, DEFAULT_CONTEXT, options=dict(graph=True))
     graph = compacted["@graph"]
     graph = [ReorderingVisitor(add_type=True).visit_schema(schema_obj) for schema_obj in graph]

--- a/python/felis/tap.py
+++ b/python/felis/tap.py
@@ -338,8 +338,10 @@ class TapLoadingVisitor(Visitor[None, tuple, Tap11Base, None, tuple, None, None]
             description = constraint_obj.get("description")
             utype = constraint_obj.get("votable:utype")
 
-            columns = [self.graph_index[c_id] for c_id in constraint_obj.get("columns", [])]
-            refcolumns = [self.graph_index[c_id] for c_id in constraint_obj.get("referencedColumns", [])]
+            columns = [self.graph_index[col["@id"]] for col in constraint_obj.get("columns", [])]
+            refcolumns = [
+                self.graph_index[refcol["@id"]] for refcol in constraint_obj.get("referencedColumns", [])
+            ]
 
             table_name = None
             for column in columns:
@@ -373,7 +375,7 @@ class TapLoadingVisitor(Visitor[None, tuple, Tap11Base, None, tuple, None, None]
 
     def visit_index(self, index_obj: _Mapping, table_obj: _Mapping) -> None:
         self.checker.check_index(index_obj, table_obj)
-        columns = [self.graph_index[c_id] for c_id in index_obj.get("columns", [])]
+        columns = [self.graph_index[col["@id"]] for col in index_obj.get("columns", [])]
         # if just one column and it's indexed, update the object
         if len(columns) == 1:
             columns[0].indexed = 1

--- a/tests/test_tap.py
+++ b/tests/test_tap.py
@@ -60,7 +60,7 @@ class VisitorTestCase(unittest.TestCase):
         Tap11Base.metadata.create_all(engine)
 
         # This repeats logic from cli.py.
-        normalized = _normalize(self.schema_obj)
+        normalized = _normalize(self.schema_obj, embed="@always")
         if isinstance(normalized["@graph"], dict):
             normalized["@graph"] = [normalized["@graph"]]
         for schema in normalized["@graph"]:


### PR DESCRIPTION
This is a fix for an issue where the `load-tap` command was failing at the command line due to how PyLD was configured. The default setting for object embedding when performing the JSON-LD "framing" was "@<!-- -->last," which embedded a referenced object once, after which its "@<!-- -->id" value was used, instead. The visitor class in Felis was processing the first constraint (foreign key) under the assumption that it would see a column object and not an "@<!-- -->id" reference. But for subsequent calls, it was only seeing the reference string value, which caused a crash.

When loading TAP, Felis is now configured to use the "@<!-- -->always" setting so that the column object data will be immediately accessible when processing constraints. The signature of the `cli._normalize()` method is updated so that the embed setting can be overridden by the caller, and the function argument maintains the default setting from PyLD, which is "@<!-- -->last." The tap module is updated with minor changes, based on the assumption that column objects will be seen during processing now, instead of references. The "@<!-- -->id" value from the column is used as a lookup into the dictionary which contains the TAP column representation. I have verified that the DDL generated by a `load-tap` dry-run is exactly the same between this branch and `main` (using the DP0.2 schema), so these changes do not appear to effect any other functionality.

As a side effect of these changes, including making the tests run successfully, the JSON output generated by various Felis commands such as `normalize` and `merge`, now contains the full column representation (object) in the constraint, rather than a reference "@<!-- -->id." The YAML output of the `modify-tap` command is also effected because it calls the `_normalize` method and needs "@<!-- -->always" to be enabled. Currently, I do not think these changes are a problem, since these particular features within Felis to generate JSON files and modify the TAP table ordering are unused by any production system or workflow. These side effects can be corrected in the future should it become necessary.