### PR TITLE
DM-41289: Make Felis fully pip installable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3
@@ -34,16 +34,49 @@ jobs:
         run: pip install -r requirements.txt
 
       # We have two cores so we can speed up the testing with xdist
-      - name: Install xdist, openfiles and flake8 for pytest
-        run: pip install "flake8<5" pytest-xdist pytest-openfiles pytest-flake8 pytest-cov
+      - name: Install pytest packages
+        run: pip install pytest pytest-xdist pytest-cov
+
+      - name: List installed packages
+        run: pip list -v
 
       - name: Build and install
-        run: pip install -v .
+        run: pip install -v --no-deps -e .
 
       - name: Run tests
-        run: pytest -r a -v -n 3 --open-files --cov=tests --cov=lsst.pex.config --cov-report=xml --cov-report=term
+        run: pytest -r a -v -n 3 --cov=tests --cov=felis --cov-report=xml --cov-report=term --cov-branch
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
+
+  pypi:
+    runs-on: ubuntu-latest
+    needs: [build_and_test]
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Need to clone everything to embed the version.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade setuptools wheel build
+
+      - name: Build and create distribution
+        run: python -m build --skip-dependency-check
+
+      - name: Upload
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_UPLOADS }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,62 @@
 [build-system]
-requires = ["setuptools", "lsst-versions"]
+requires = ["setuptools", "lsst-versions >= 1.3.0"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "felis"
+description = "A vocabulary for describing catalogs and acting on those descriptions"
+license = {text = "GNU General Public License v3 or later (GPLv3+)"}
+readme = "README.md"
+authors = [
+    {name="Rubin Observatory Data Management", email="dm-admin@lists.lsst.org"},
+]
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Astronomy"
+]
+keywords = ["lsst"]
+dependencies = [
+    "astropy >= 4",
+    "sqlalchemy >= 1.4",
+    "click >= 7",
+    "pyyaml >= 6",
+    "pyld >= 2",
+    "pydantic >= 2, < 3"
+]
+requires-python = ">=3.11.0"
+dynamic = ["version"]
+
+[project.urls]
+"Homepage" = "https://github.com/lsst/felis"
+
+[project.optional-dependencies]
+test = [
+    "pytest >= 3.2"
+]
+
+[tool.pytest.ini_options]
+
+[tool.setuptools.packages.find]
+where = ["python"]
+
+[tool.setuptools]
+zip-safe = true
+license-files = ["COPYRIGHT", "LICENSE"]
+
+[tool.setuptools.package-data]
+"felis" = ["py.typed"]
+
+[tool.setuptools.dynamic]
+version = { attr = "lsst_versions.get_lsst_version" }
+
+[project.scripts]
+felis = "felis.cli:cli"
+
 
 [tool.towncrier]
     package = "felis"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,53 +1,5 @@
-[metadata]
-name = felis
-description = A vocabulary for describing catalogs and acting on those descriptions
-author = Rubin Observatory Data Management
-url = https://github.com/lsst-dm/felis
-classifiers =
-	Intended Audience :: Science/Research
-	License :: OSI Approved ::  GNU General Public License v3 or later (GPLv3+)
-	Operating System :: OS Independent
-	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.10
-	Programming Language :: Python :: 3.11
-	Topic :: Scientific/Engineering :: Astronomy
-long_description = file: README.md
-long_description_content_type = text/markdown
-version = attr: lsst.felis.__version__
-
-[options]
-zip_safe = True
-package_dir =
-	=python
-packages = find:
-setup_requires =
-	setuptools >=46.0
-install_requires =
-	astropy
-	sqlalchemy
-	pyyaml
-	pyld
-	click
-tests_require =
-	pytest >= 3.2
-	flake8 >= 3.7.5
-	pytest-flake8 >= 1.0.4
-	pytest-openfiles >= 0.5.0
-
-[options.entry_points]
-console_scripts =
-	felis = felis.cli:cli
-
-[options.packages.find]
-where = python
-
-[options.package_data]
-felis = py.typed
-
 [flake8]
 max-line-length = 110
 max-doc-length = 79
 ignore = E203, W503, N802, N803, N806, N812, N815, N816
 exclude = __init__.py
-
-[tool:pytest]


### PR DESCRIPTION
 Configuration was updated so that felis will be pip installable using:

```    
pip install felis
```
    
The DM developer documentation was used for guidance:
    
https://developer.lsst.io/stack/building-with-pip.html
    
Existing configuration was moved from setup.cfg to pyproject.toml where relevant.

A new job was added to `build.yaml` which publishes the package to PyPI.

A valid token needs to be added as a project secret called `PYPI_UPLOADS` for the publication to work.