### PR TITLE
DM-41289: Fix requirements to match those in pyproject.toml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-astropy
+astropy >= 4
 sqlalchemy >= 1.4
-click
-pyyaml
-pyld
+click >= 7
+pyyaml >= 6
+pyld >= 2
 pydantic >= 2, < 3


### PR DESCRIPTION
The requirements in DM-41289 were accidentally overwritten while resolving a conflict. This fixes them to match the ones in the pyproject.toml config.