### PR TITLE
DM-42446: Add RSP schema validation

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -5,6 +5,7 @@ warn_redundant_casts = True
 ignore_missing_imports = False
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
+plugins = pydantic.mypy
 
 [mypy-sqlalchemy.*]
 ignore_missing_imports = True

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -314,7 +314,7 @@ def merge(files: Iterable[io.TextIOBase]) -> None:
 def validate(schema_name: str, files: Iterable[io.TextIOBase]) -> None:
     """Validate one or more felis YAML files."""
     schema_class: Type[Schema] = get_schema(schema_name)
-    logger.info(f"Using schema {schema_class.__name__}")
+    logger.info(f"Using schema '{schema_class.__name__}'")
 
     rc = 0
     for file in files:

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -310,11 +310,15 @@ def merge(files: Iterable[io.TextIOBase]) -> None:
     type=click.Choice(["RSP", "default"]),
     default="default",
 )
+@click.option("-d", "--require-description", is_flag=True, help="Require description for all objects")
 @click.argument("files", nargs=-1, type=click.File())
-def validate(schema_name: str, files: Iterable[io.TextIOBase]) -> None:
+def validate(schema_name: str, require_description: bool, files: Iterable[io.TextIOBase]) -> None:
     """Validate one or more felis YAML files."""
     schema_class: Type[Schema] = get_schema(schema_name)
     logger.info(f"Using schema '{schema_class.__name__}'")
+
+    if require_description:
+        Schema.require_description(True)
 
     rc = 0
     for file in files:

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -388,7 +388,7 @@ class Schema(BaseObject):
         return tables
 
     @model_validator(mode="after")
-    def create_id_map(self) -> "Schema":
+    def create_id_map(self: "Schema") -> "Schema":
         """Create a map of IDs to objects."""
         visitor: SchemaVisitor = SchemaVisitor()
         visitor.visit_schema(self)

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -305,10 +305,10 @@ class SchemaVersion(BaseModel):
     current: str
     """The current version of the schema."""
 
-    compatible: list[str] | None = None
+    compatible: list[str] = Field(default_factory=list)
     """The compatible versions of the schema."""
 
-    read_compatible: list[str] | None = None
+    read_compatible: list[str] = Field(default_factory=list)
     """The read compatible versions of the schema."""
 
 

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -22,7 +22,7 @@
 import logging
 from collections.abc import Mapping
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Literal, Sequence
 
 from astropy import units as units  # type: ignore
 from astropy.io.votable import ucd  # type: ignore
@@ -243,7 +243,7 @@ class ForeignKeyConstraint(Constraint):
 class Table(BaseObject):
     """A database table."""
 
-    columns: list[Column]
+    columns: Sequence[Column]
     """The columns in the table."""
 
     constraints: list[Constraint] = Field(default_factory=list)
@@ -373,7 +373,7 @@ class Schema(BaseObject):
     version: SchemaVersion | str | None = None
     """The version of the schema."""
 
-    tables: list[Table]
+    tables: Sequence[Table]
     """The tables in the schema."""
 
     id_map: dict[str, Any] = Field(default_factory=dict, exclude=True)

--- a/python/felis/types.py
+++ b/python/felis/types.py
@@ -28,7 +28,7 @@ class FelisType:
     """Base class for types that represent Felis column types.
 
     This class plays a role of a metaclass without being an actual metaclass.
-    It provides a method to retrieve a c;ass (type) given Felis type name.
+    It provides a method to retrieve a class (type) given Felis type name.
     There should be no instances of this class (or sub-classes), the utility
     of the class hierarchy is in the type system itself.
     """

--- a/python/felis/validation.py
+++ b/python/felis/validation.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-from typing import Type
+from typing import Any, Type
 
 from pydantic import Field, model_validator
 
@@ -46,8 +46,7 @@ class RspTable(Table):
     """
 
     description: str = Field(..., min_length=1)
-    """Redefine description so that it is required and non-empty.
-    """
+    """Redefine description so that it is required and non-empty."""
 
     tap_table_index: int = Field(..., alias="tap:table_index")
     """Redefine the TAP_SCHEMA table index so that it is required."""
@@ -57,7 +56,7 @@ class RspTable(Table):
 
     @model_validator(mode="after")  # type: ignore
     @classmethod
-    def check_tap_principal(cls, tbl: "RspTable") -> "RspTable":
+    def check_tap_principal(cls: Any, tbl: "RspTable") -> "RspTable":
         """Check that at least one column is flagged as the TAP principal."""
         for col in tbl.columns:
             if col.tap_principal == 1:
@@ -80,7 +79,7 @@ class RspSchema(Schema):
 
     @model_validator(mode="after")  # type: ignore
     @classmethod
-    def check_tap_table_indexes(cls, sch: "RspSchema") -> "RspSchema":
+    def check_tap_table_indexes(cls: Any, sch: "RspSchema") -> "RspSchema":
         """Check that the TAP table indexes are unique."""
         table_indicies = set()
         for table in sch.tables:

--- a/python/felis/validation.py
+++ b/python/felis/validation.py
@@ -22,22 +22,17 @@
 import logging
 from typing import Any, Sequence, Type
 
-from pydantic import Field, constr, model_validator
+from pydantic import Field, model_validator
 
-from .datamodel import Column, Schema, Table
+from .datamodel import DESCR_MIN_LENGTH, Column, Schema, Table
 
 logger = logging.getLogger(__name__)
-
-NonEmptyStrippedStr = constr(strip_whitespace=True, min_length=3)
-"""A string type that is required to be non-empty after being stripped of
-whitespace.
-"""
 
 
 class RspColumn(Column):
     """Column for RSP data validation."""
 
-    description: NonEmptyStrippedStr  # type: ignore[valid-type]
+    description: str = Field(..., min_length=DESCR_MIN_LENGTH)
     """Redefine description to make it required and non-empty.
     """
 
@@ -50,8 +45,8 @@ class RspTable(Table):
     Tables for the RSP must have a TAP table index and a valid description.
     """
 
-    description: NonEmptyStrippedStr  # type: ignore[valid-type]
-    """Redefine description so that it is required and non-empty."""
+    description: str = Field(..., min_length=DESCR_MIN_LENGTH)
+    """Redefine description so that it is required."""
 
     tap_table_index: int = Field(..., alias="tap:table_index")
     """Redefine the TAP_SCHEMA table index so that it is required."""
@@ -77,7 +72,7 @@ class RspSchema(Schema):
     TAP table indexes must be unique across all tables.
     """
 
-    description: str = Field(..., min_length=1)
+    description: str = Field(..., min_length=DESCR_MIN_LENGTH)
     """Redefine description to make it required and non-empty.
     """
 

--- a/python/felis/validation.py
+++ b/python/felis/validation.py
@@ -1,0 +1,102 @@
+# This file is part of felis.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+from typing import Type
+
+from pydantic import Field, model_validator
+
+from .datamodel import Column, Schema, Table
+
+logger = logging.getLogger(__name__)
+
+
+class RspColumn(Column):
+    """Column for RSP data validation."""
+
+    description: str = Field(..., min_length=1)
+    """Redefine description to make it required and non-empty.
+    """
+
+
+class RspTable(Table):
+    """Table for RSP data validation.
+
+    The list of columns is overridden to use RspColumn instead of Column.
+
+    Tables for the RSP must have a TAP table index and a valid description.
+    """
+
+    description: str = Field(..., min_length=1)
+    """Redefine description so that it is required and non-empty.
+    """
+
+    tap_table_index: int | None = Field(..., alias="tap:table_index")
+    """Redefine the TAP_SCHEMA table index so that it is required."""
+
+    columns: list[RspColumn]  # type: ignore
+    """Redefine columns to include RSP validation."""
+
+    @model_validator(mode="after")  # type: ignore
+    @classmethod
+    def check_tap_principal(cls, tbl: "RspTable") -> "RspTable":
+        """Check that at least one column is flagged as the TAP principal."""
+        for col in tbl.columns:
+            if col.tap_principal == 1:
+                return tbl
+        raise ValueError(f"Table '{tbl.name}' is missing at least one column designated as 'tap:principal'")
+
+
+class RspSchema(Schema):
+    """Schema for RSP data validation.
+
+    TAP table indexes must be unique across all tables.
+    """
+
+    description: str = Field(..., min_length=1)
+    """Redefine description to make it required and non-empty.
+    """
+
+    tables: list[RspTable]  # type: ignore
+    """Redefine tables to include RSP validation."""
+
+    @model_validator(mode="after")  # type: ignore
+    @classmethod
+    def check_tap_table_indexes(cls, sch: "RspSchema") -> "RspSchema":
+        """Check that the TAP table indexes are unique."""
+        table_indicies = set()
+        for table in sch.tables:
+            table_index = table.tap_table_index
+            if table_index is not None:
+                if table_index in table_indicies:
+                    raise ValueError(f"Duplicate 'tap:table_index' value {table_index} found in schema")
+                table_indicies.add(table_index)
+        return sch
+
+
+def get_schema(schema_name: str) -> Type[Schema]:
+    """Get the schema class for the given name."""
+    if schema_name == "default":
+        return Schema
+    elif schema_name == "RSP":
+        return RspSchema
+    else:
+        raise ValueError(f"Unknown schema name '{schema_name}'")

--- a/python/felis/validation.py
+++ b/python/felis/validation.py
@@ -22,17 +22,22 @@
 import logging
 from typing import Any, Sequence, Type
 
-from pydantic import Field, model_validator
+from pydantic import Field, constr, model_validator
 
 from .datamodel import Column, Schema, Table
 
 logger = logging.getLogger(__name__)
 
+NonEmptyStrippedStr = constr(strip_whitespace=True, min_length=3)
+"""A string type that is required to be non-empty after being stripped of
+whitespace.
+"""
+
 
 class RspColumn(Column):
     """Column for RSP data validation."""
 
-    description: str = Field(..., min_length=1)
+    description: NonEmptyStrippedStr  # type: ignore[valid-type]
     """Redefine description to make it required and non-empty.
     """
 
@@ -45,7 +50,7 @@ class RspTable(Table):
     Tables for the RSP must have a TAP table index and a valid description.
     """
 
-    description: str = Field(..., min_length=1)
+    description: NonEmptyStrippedStr  # type: ignore[valid-type]
     """Redefine description so that it is required and non-empty."""
 
     tap_table_index: int = Field(..., alias="tap:table_index")
@@ -54,7 +59,7 @@ class RspTable(Table):
     columns: Sequence[RspColumn]
     """Redefine columns to include RSP validation."""
 
-    @model_validator(mode="after")  # type: ignore
+    @model_validator(mode="after")  # type: ignore[arg-type]
     @classmethod
     def check_tap_principal(cls: Any, tbl: "RspTable") -> "RspTable":
         """Check that at least one column is flagged as 'principal' for
@@ -79,7 +84,7 @@ class RspSchema(Schema):
     tables: Sequence[RspTable]
     """Redefine tables to include RSP validation."""
 
-    @model_validator(mode="after")  # type: ignore
+    @model_validator(mode="after")  # type: ignore[arg-type]
     @classmethod
     def check_tap_table_indexes(cls: Any, sch: "RspSchema") -> "RspSchema":
         """Check that the TAP table indexes are unique."""

--- a/python/felis/validation.py
+++ b/python/felis/validation.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-from typing import Any, Type
+from typing import Any, Sequence, Type
 
 from pydantic import Field, model_validator
 
@@ -51,7 +51,7 @@ class RspTable(Table):
     tap_table_index: int = Field(..., alias="tap:table_index")
     """Redefine the TAP_SCHEMA table index so that it is required."""
 
-    columns: list[RspColumn]  # type: ignore
+    columns: Sequence[RspColumn]
     """Redefine columns to include RSP validation."""
 
     @model_validator(mode="after")  # type: ignore
@@ -74,7 +74,7 @@ class RspSchema(Schema):
     """Redefine description to make it required and non-empty.
     """
 
-    tables: list[RspTable]  # type: ignore
+    tables: Sequence[RspTable]
     """Redefine tables to include RSP validation."""
 
     @model_validator(mode="after")  # type: ignore

--- a/python/felis/validation.py
+++ b/python/felis/validation.py
@@ -49,7 +49,7 @@ class RspTable(Table):
     """Redefine description so that it is required and non-empty.
     """
 
-    tap_table_index: int | None = Field(..., alias="tap:table_index")
+    tap_table_index: int = Field(..., alias="tap:table_index")
     """Redefine the TAP_SCHEMA table index so that it is required."""
 
     columns: list[RspColumn]  # type: ignore

--- a/python/felis/validation.py
+++ b/python/felis/validation.py
@@ -57,7 +57,9 @@ class RspTable(Table):
     @model_validator(mode="after")  # type: ignore
     @classmethod
     def check_tap_principal(cls: Any, tbl: "RspTable") -> "RspTable":
-        """Check that at least one column is flagged as the TAP principal."""
+        """Check that at least one column is flagged as 'principal' for
+        TAP purposes.
+        """
         for col in tbl.columns:
             if col.tap_principal == 1:
                 return tbl

--- a/tests/data/test.yml
+++ b/tests/data/test.yml
@@ -80,6 +80,7 @@ tables:
         "@id": "#UQ_sdqaMetric_metricName"
         "@type": Unique
         columns: ["#sdqa_Metric.metricName"]
+        description: Unique constraint on metricName.
     mysql:engine: MyISAM
 
   - name: sdqa_Rating_ForAmpVisit
@@ -126,23 +127,28 @@ tables:
       - name: UQ_sdqaRatingForAmpVisit_metricId_ampVisitId
         "@id": "#UQ_sdqaRatingForAmpVisit_metricId_ampVisitId"
         "@type": Unique
+        description: Unique constraint on metricId and ampVisitId.
         columns:
           - "#sdqa_Rating_ForAmpVisit.sdqa_metricId"
           - "#sdqa_Rating_ForAmpVisit.ampVisitId"
       - name: FK_sdqa_Rating_ForAmpVisit_sdqa_Metric
         "@id": "#FK_sdqa_Rating_ForAmpVisit_sdqa_Metric"
         "@type": ForeignKey
+        description: Foreign key constraint on sdqa_metricId.
         columns: ["#sdqa_Rating_ForAmpVisit.sdqa_metricId"]
         referencedColumns: ["#sdqa_Metric.sdqa_metricId"]
     indexes:
       - name: IDX_sdqaRatingForAmpVisit_metricId
         "@id": "#IDX_sdqaRatingForAmpVisit_metricId"
+        description: Index on metricId.
         columns: ["#sdqa_Rating_ForAmpVisit.sdqa_metricId"]
       - name: IDX_sdqaRatingForAmpVisit_thresholdId
         "@id": "#IDX_sdqaRatingForAmpVisit_thresholdId"
+        description: Index on thresholdId.
         columns: ["#sdqa_Rating_ForAmpVisit.sdqa_thresholdId"]
       - name: IDX_sdqaRatingForAmpVisit_ampVisitId
         "@id": "#IDX_sdqaRatingForAmpVisit_ampVisitId"
+        description: Index on ampVisitId.
         columns: ["#sdqa_Rating_ForAmpVisit.ampVisitId"]
     mysql:engine: MyISAM
 
@@ -189,18 +195,22 @@ tables:
       - name: UQ_sdqaRatingCcdVisit_metricId_ccdVisitId
         "@id": "#UQ_sdqaRatingCcdVisit_metricId_ccdVisitId"
         "@type": Unique
+        description: Unique constraint on metricId and ccdVisitId.
         columns:
           - "#sdqa_Rating_CcdVisit.sdqa_metricId"
           - "#sdqa_Rating_CcdVisit.ccdVisitId"
     indexes:
       - name: IDX_sdqaRatingCcdVisit_metricId
         "@id": "#IDX_sdqaRatingCcdVisit_metricId"
+        description: Index on metricId.
         columns: ["#sdqa_Rating_CcdVisit.sdqa_metricId"]
       - name: IDX_sdqaRatingCcdVisit_thresholdId
         "@id": "#IDX_sdqaRatingCcdVisit_thresholdId"
+        description: Index on thresholdId.
         columns: ["#sdqa_Rating_CcdVisit.sdqa_thresholdId"]
       - name: IDX_sdqaRatingCcdVisit_ccdVisitId
         "@id": "#IDX_sdqaRatingCcdVisit_ccdVisitId"
+        description: Index on ccdVisitId.
         columns: ["#sdqa_Rating_CcdVisit.ccdVisitId"]
     mysql:engine: MyISAM
 
@@ -245,5 +255,6 @@ tables:
     indexes:
       - name: IDX_sdqaThreshold_metricId
         "@id": "#IDX_sdqaThreshold_metricId"
+        description: Index on metricId.
         columns: ["#sdqa_Threshold.sdqa_metricId"]
     mysql:engine: MyISAM

--- a/tests/data/test.yml
+++ b/tests/data/test.yml
@@ -11,12 +11,14 @@ tables:
     '@id': "#sdqa_ImageStatus"
     description: Unique set of status names and their definitions, e.g.
       'passed', 'failed', etc.
+    tap:table_index: 1
     columns:
       - name: sdqa_imageStatusId
         "@id": "#sdqa_ImageStatus.sdqa_imageStatusId"
         datatype: short
         description: Primary key
         mysql:datatype: SMALLINT
+        tap:principal: 1
       - name: statusName
         "@id": "#sdqa_ImageStatus.statusName"
         datatype: string
@@ -38,12 +40,14 @@ tables:
     description: Unique set of metric names and associated metadata (e.g.,
       'nDeadPix';, 'median';, etc.). There will be approximately 30 records
       total in this table.
+    tap:table_index: 2
     columns:
       - name: sdqa_metricId
         "@id": "#sdqa_Metric.sdqa_metricId"
         datatype: short
         description: Primary key.
         mysql:datatype: SMALLINT
+        tap:principal: 1
       - name: metricName
         "@id": "#sdqa_Metric.metricName"
         datatype: string
@@ -67,6 +71,7 @@ tables:
       - name: definition
         "@id": "#sdqa_Metric.definition"
         datatype: string
+        description: Detailed definition of the metric.
         length: 255
         mysql:datatype: VARCHAR(255)
     primaryKey: "#sdqa_Metric.sdqa_metricId"
@@ -81,6 +86,7 @@ tables:
     "@id": "#sdqa_Rating_ForAmpVisit"
     description: Various SDQA ratings for a given amplifier image. There will
       be approximately 30 of these records per image record.
+    tap:table_index: 3
     columns:
       - name: sdqa_ratingId
         "@id": "#sdqa_Rating_ForAmpVisit.sdqa_ratingId"
@@ -88,6 +94,7 @@ tables:
         description: Primary key. Auto-increment is used, we define a composite
           unique key, so potential duplicates will be captured.
         mysql:datatype: BIGINT
+        tap:principal: 1
       - name: sdqa_metricId
         "@id": "#sdqa_Rating_ForAmpVisit.sdqa_metricId"
         datatype: short
@@ -142,6 +149,7 @@ tables:
   - name: sdqa_Rating_CcdVisit
     "@id": "#sdqa_Rating_CcdVisit"
     description: Various SDQA ratings for a given CcdVisit.
+    tap:table_index: 4
     columns:
       - name: sdqa_ratingId
         "@id": "#sdqa_Rating_CcdVisit.sdqa_ratingId"
@@ -149,6 +157,7 @@ tables:
         description: Primary key. Auto-increment is used, we define a composite
           unique key, so potential duplicates will be captured.
         mysql:datatype: BIGINT
+        tap:principal: 1
       - name: sdqa_metricId
         "@id": "#sdqa_Rating_CcdVisit.sdqa_metricId"
         datatype: short
@@ -201,12 +210,14 @@ tables:
       records is approximately equal to 30 x the number of times the thresholds
       will be changed over the entire period of LSST operations (of order of
       100), with most of the changes occuring in the first year of operations.
+    tap:table_index: 5
     columns:
       - name: sdqa_thresholdId
         "@id": "#sdqa_Threshold.sdqa_thresholdId"
         datatype: short
         description: Primary key.
         mysql:datatype: SMALLINT
+        tap:principal: 1
       - name: sdqa_metricId
         "@id": "#sdqa_Threshold.sdqa_metricId"
         datatype: short

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ TEST_MERGE_YAML = os.path.join(TESTDIR, "data", "test-merge.yml")
 
 
 class CliTestCase(unittest.TestCase):
-    """Tests for TapLoadingVisitor class."""
+    """Tests for CLI commands."""
 
     schema_obj: MutableMapping[str, Any] | None = None
 
@@ -125,6 +125,18 @@ class CliTestCase(unittest.TestCase):
         runner = CliRunner()
 
         result = runner.invoke(cli, ["merge", TEST_YAML, TEST_MERGE_YAML], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+
+    def test_validate_default(self) -> None:
+        """Test for validate command."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", TEST_YAML], catch_exceptions=False)
+        self.assertEqual(result.exit_code, 0)
+
+    def test_validate_rsp(self) -> None:
+        """Test for validation using the RSP schema type."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "-s", "RSP", TEST_YAML], catch_exceptions=False)
         self.assertEqual(result.exit_code, 0)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,7 @@ from typing import Any
 from click.testing import CliRunner
 
 from felis.cli import cli
+from felis.datamodel import Schema
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 TEST_YAML = os.path.join(TESTDIR, "data", "test.yml")
@@ -128,13 +129,23 @@ class CliTestCase(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
 
     def test_validate_default(self) -> None:
-        """Test for validate command."""
+        """Test validate command."""
         runner = CliRunner()
         result = runner.invoke(cli, ["validate", TEST_YAML], catch_exceptions=False)
         self.assertEqual(result.exit_code, 0)
 
+    def test_validate_default_with_require_description(self) -> None:
+        """Test validate command with description required."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["validate", "--require-description", TEST_YAML], catch_exceptions=False)
+        # This state needs to be reset for subsequent tests or some will fail.
+        # This is not an issue when running the actual command line tool, which
+        # will execute in its own system process.
+        Schema.require_description(False)
+        self.assertEqual(result.exit_code, 0)
+
     def test_validate_rsp(self) -> None:
-        """Test for validation using the RSP schema type."""
+        """Test RSP schema type validation."""
         runner = CliRunner()
         result = runner.invoke(cli, ["validate", "-s", "RSP", TEST_YAML], catch_exceptions=False)
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -42,7 +42,7 @@ TEST_YAML = os.path.join(TESTDIR, "data", "test.yml")
 
 
 class DataModelTestCase(unittest.TestCase):
-    """Test validation a test schema from a YAML file."""
+    """Test validation of a test schema from a YAML file."""
 
     schema_obj: Schema
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -367,15 +367,24 @@ class SchemaTestCase(unittest.TestCase):
                 ],
             )
 
-    def test_id_map(self) -> None:
+    def test_schema_object_ids(self) -> None:
         """Test that the id_map is properly populated."""
         test_col = Column(name="testColumn", id="#test_col_id", datatype="string")
         test_tbl = Table(name="testTable", id="#test_table_id", columns=[test_col])
         sch = Schema(name="testSchema", id="#test_schema_id", tables=[test_tbl])
 
         for id in ["#test_col_id", "#test_table_id", "#test_schema_id"]:
-            # Test that the id_map contains the expected id.
-            sch.get_object_by_id(id)
+            # Test that the schema contains the expected id.
+            self.assertTrue(id in sch, f"schema should contain '{id}'")
+
+        # Check that types of returned objects are correct.
+        self.assertIsInstance(sch["#test_col_id"], Column, "schema[id] should return a Column")
+        self.assertIsInstance(sch["#test_table_id"], Table, "schema[id] should return a Table")
+        self.assertIsInstance(sch["#test_schema_id"], Schema, "schema[id] should return a Schema")
+
+        with self.assertRaises(ValueError):
+            # Test that an invalid id raises an exception.
+            sch["#bad_id"]
 
 
 class SchemaVersionTest(unittest.TestCase):

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -121,6 +121,27 @@ class ColumnTestCase(unittest.TestCase):
         with self.assertRaises(ValidationError):
             Column(**units_data)
 
+        # Turn on description requirement for next two tests.
+        Schema.require_description(True)
+
+        # Make sure that setting the flag for description requirement works
+        # correctly.
+        self.assertTrue(Schema.is_description_required(), "description should be required")
+
+        # Creating a column without a description when required should throw an
+        # error.
+        with self.assertRaises(ValidationError):
+            col = Column(
+                **{
+                    "name": "testColumn",
+                    "@id": "#test_col_id",
+                    "datatype": "string",
+                }
+            )
+
+        # Turn off flag or it will affect subsequent tests.
+        Schema.require_description(False)
+
 
 class ConstraintTestCase(unittest.TestCase):
     """Test the `UniqueConstraint`, `Index`, `CheckCosntraint`, and

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -89,14 +89,14 @@ class VisitorTestCase(unittest.TestCase):
         self.assertEqual(
             [column.annotations for column in table.columns],
             [
-                {"mysql:datatype": "SMALLINT"},
+                {"mysql:datatype": "SMALLINT", "tap:principal": 1},
                 {"mysql:datatype": "VARCHAR(30)"},
                 {"mysql:datatype": "VARCHAR(255)"},
             ],
         )
         self.assertEqual(_names(table.primary_key), ["sdqa_imageStatusId"])
         self.assertFalse(table.indexes)
-        self.assertEqual(table.annotations, {"mysql:engine": "MyISAM"})
+        self.assertEqual(table.annotations, {"mysql:engine": "MyISAM", "tap:table_index": 1})
 
         # Details of sdqa_Metric table.
         table = tables["sdqa_Metric"]
@@ -110,7 +110,7 @@ class VisitorTestCase(unittest.TestCase):
         self.assertEqual([column.length for column in table.columns], [None, 30, 30, 1, 255])
         self.assertEqual(_names(table.primary_key), ["sdqa_metricId"])
         self.assertFalse(table.indexes)
-        self.assertEqual(table.annotations, {"mysql:engine": "MyISAM"})
+        self.assertEqual(table.annotations, {"mysql:engine": "MyISAM", "tap:table_index": 2})
 
         # It defines a unique constraint.
         self.assertEqual(len(table.constraints), 1)
@@ -139,7 +139,7 @@ class VisitorTestCase(unittest.TestCase):
             [column.datatype for column in table.columns],
             [types.Long, types.Short, types.Short, types.Long, types.Double, types.Double],
         )
-        self.assertEqual(table.annotations, {"mysql:engine": "MyISAM"})
+        self.assertEqual(table.annotations, {"mysql:engine": "MyISAM", "tap:table_index": 3})
 
         # constraints
         self.assertEqual(len(table.constraints), 2)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,203 @@
+# This file is part of felis.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+from pydantic import ValidationError
+
+from felis.datamodel import Schema
+from felis.validation import RspColumn, RspSchema, RspTable, get_schema
+
+
+class RSPSchemaTestCase(unittest.TestCase):
+    """Test validation of RSP schema data."""
+
+    def test_rsp_validation(self) -> None:
+        # Creating an empty RSP column should throw an exception.
+        with self.assertRaises(ValidationError):
+            RspColumn()
+
+        # Missing column description should throw an exception.
+        with self.assertRaises(ValidationError):
+            RspColumn(name="testColumn", id="#test_col_id", datatype="string")
+
+        # Creating a valid RSP column should not throw an exception.
+        col = RspColumn(
+            **{
+                "name": "testColumn",
+                "@id": "#test_col_id",
+                "datatype": "string",
+                "description": "test column",
+                "tap:principal": 1,
+            }
+        )
+
+        # Creating an empty RSP table should throw an exception.
+        with self.assertRaises(ValidationError):
+            RspTable()
+
+        # Missing table description should throw an exception.
+        with self.assertRaises(ValidationError):
+            RspTable(**{"name": "testTable", "@id": "#test_table_id", "tap:table_index": 1}, columns=[col])
+
+        # Missing TAP table index should throw an exception.
+        with self.assertRaises(ValidationError):
+            RspTable(name="testTable", id="#test_table_id", description="test table", columns=[col])
+
+        # Missing at least one column flagged as TAP principal should throw an
+        # exception.
+        with self.assertRaises(ValidationError):
+            RspTable(
+                **{
+                    "name": "testTable",
+                    "@id": "#test_table_id",
+                    "description": "test table",
+                    "tap:table_index": 1,
+                    "columns": [
+                        RspColumn(
+                            **{
+                                "name": "testColumn",
+                                "@id": "#test_col_id",
+                                "datatype": "string",
+                                "description": "test column",
+                            }
+                        )
+                    ],
+                }
+            )
+
+        # Creating a valid RSP table should not throw an exception.
+        tbl = RspTable(
+            **{
+                "name": "testTable",
+                "@id": "#test_table_id",
+                "description": "test table",
+                "tap:table_index": 1,
+                "columns": [col],
+            }
+        )
+
+        # Creating an empty RSP table schema throw an exception.
+        with self.assertRaises(ValidationError):
+            RspSchema(tables=[tbl])
+
+        # Creating a schema with duplicate TAP table indices should throw an exception.
+        with self.assertRaises(ValidationError):
+            RspSchema(
+                **{"name": "testSchema", "@id": "#test_schema_id", "description": "test schema"},
+                tables=[
+                    RspTable(
+                        **{
+                            "name": "testTable1",
+                            "@id": "#test_table1_id",
+                            "description": "test table",
+                            "tap:table_index": 1,
+                            "columns": [
+                                RspColumn(
+                                    **{
+                                        "name": "testColumn",
+                                        "@id": "#test_col1_id",
+                                        "datatype": "string",
+                                        "description": "test column",
+                                        "tap:principal": 1,
+                                    }
+                                )
+                            ],
+                        }
+                    ),
+                    RspTable(
+                        **{
+                            "name": "testTable2",
+                            "@id": "#test_table2_id",
+                            "description": "test table",
+                            "tap:table_index": 1,
+                            "columns": [
+                                RspColumn(
+                                    **{
+                                        "name": "testColumn",
+                                        "@id": "#test_col2_id",
+                                        "datatype": "string",
+                                        "description": "test column",
+                                        "tap:principal": 1,
+                                    }
+                                )
+                            ],
+                        }
+                    ),
+                ],
+            )
+
+        # Creating a valid schema with multiple tables having unique TAP table
+        # indices should not throw a exception.
+        RspSchema(
+            **{"name": "testSchema", "@id": "#test_schema_id", "description": "test schema"},
+            tables=[
+                RspTable(
+                    **{
+                        "name": "testTable",
+                        "@id": "#test_table_id",
+                        "description": "test table",
+                        "tap:table_index": 1,
+                        "columns": [
+                            RspColumn(
+                                **{
+                                    "name": "testColumn",
+                                    "@id": "#test_col1_id",
+                                    "datatype": "string",
+                                    "description": "test column",
+                                    "tap:principal": 1,
+                                }
+                            )
+                        ],
+                    }
+                ),
+                RspTable(
+                    **{
+                        "name": "testTable2",
+                        "@id": "#test_table2_id",
+                        "description": "test table",
+                        "tap:table_index": 2,
+                        "columns": [
+                            RspColumn(
+                                **{
+                                    "name": "testColumn",
+                                    "@id": "#test_col2_id",
+                                    "datatype": "string",
+                                    "description": "test column",
+                                    "tap:principal": 1,
+                                }
+                            )
+                        ],
+                    }
+                ),
+            ],
+        )
+
+    def test_get_schema(self) -> None:
+        """Test that get_schema() returns the correct schema types."""
+        rsp_schema: RspSchema = get_schema("RSP")
+        self.assertEqual(rsp_schema.__name__, "RspSchema")
+
+        default_schema: Schema = get_schema("default")
+        self.assertEqual(default_schema.__name__, "Schema")
+
+        with self.assertRaises(ValueError):
+            get_schema("invalid_schema")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -99,7 +99,8 @@ class RSPSchemaTestCase(unittest.TestCase):
         with self.assertRaises(ValidationError):
             RspSchema(tables=[tbl])
 
-        # Creating a schema with duplicate TAP table indices should throw an exception.
+        # Creating a schema with duplicate TAP table indices should throw an
+        # exception.
         with self.assertRaises(ValidationError):
             RspSchema(
                 **{"name": "testSchema", "@id": "#test_schema_id", "description": "test schema"},

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -39,6 +39,14 @@ class RSPSchemaTestCase(unittest.TestCase):
         with self.assertRaises(ValidationError):
             RspColumn(name="testColumn", id="#test_col_id", datatype="string")
 
+        # A column description with only whitespace should throw an exception.
+        with self.assertRaises(ValidationError):
+            RspColumn(name="testColumn", id="#test_col_id", datatype="string", description="  ")
+
+        # A column description of `None` should throw an exception.
+        with self.assertRaises(ValidationError):
+            RspColumn(name="testColumn", id="#test_col_id", datatype="string", description=None)
+
         # Creating a valid RSP column should not throw an exception.
         col = RspColumn(
             **{
@@ -57,6 +65,20 @@ class RSPSchemaTestCase(unittest.TestCase):
         # Missing table description should throw an exception.
         with self.assertRaises(ValidationError):
             RspTable(**{"name": "testTable", "@id": "#test_table_id", "tap:table_index": 1}, columns=[col])
+
+        # A table description with only whitespace should throw an exception.
+        with self.assertRaises(ValidationError):
+            RspTable(
+                **{"name": "testTable", "@id": "#test_table_id", "tap:table_index": 1, "description": "  "},
+                columns=[col],
+            )
+
+        # A table description of `None` should throw an exception.
+        with self.assertRaises(ValidationError):
+            RspTable(
+                **{"name": "testTable", "@id": "#test_table_id", "tap:table_index": 1, "description": None},
+                columns=[col],
+            )
 
         # Missing TAP table index should throw an exception.
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
RSP schema validation is implemented using a set of extension classes in a new validation module. The validation rules were based on those in the sdm_schemas repository under `tap-schema/validator`.

These new rules check that:

- All columns have a non-empty description
- All tables have a non-empty description, a TAP_SCHEMA table index, and at least one column flagged as TAP_SCHEMA principal
- The schema has a non-empty description and a set of unique (non-duplicated) TAP_SCHEMA table indices

Tests for the new module and its functionality were added under `tests/test_validation.py`.

A schema type can be selected from the command-line now using a syntax such as:

```
felis validate -s RSP ../sdm_schemas/yml/dp02_dc2.yaml
```

I tested the new validation on the above schema and found some expected errors where at least one TAP_SCHEMA principal column needed to be defined and was missing.

I have also added a flag that will make description required for all objects in the schema. It can be enabled as follows:

```
felis validate --require-description ../sdm_schemas/yml/dp02_dc2.yaml
```

This will require descriptions on _every_ object, including the schema itself, tables, columns, and constraints. (RSP validation will only add the extra description requirement for columns.)