### PR TITLE
DM-42291: Provide a default argument for schema renumbering to modify-tap command

### DIFF
--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -204,7 +204,7 @@ def load_tap(
 
 
 @cli.command("modify-tap")
-@click.option("--start-schema-at", type=int, help="Rewrite index for tap:schema_index")
+@click.option("--start-schema-at", type=int, help="Rewrite index for tap:schema_index", default=0)
 @click.argument("files", nargs=-1, type=click.File())
 def modify_tap(start_schema_at: int, files: Iterable[io.TextIOBase]) -> None:
     """Modify TAP information in Felis schema FILES.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,10 +117,6 @@ class CliTestCase(unittest.TestCase):
         """Test for modify-tap command."""
         runner = CliRunner()
 
-        # Without --start-schema-at it makes an exception
-        with self.assertRaises(TypeError):
-            result = runner.invoke(cli, ["modify-tap", TEST_YAML], catch_exceptions=False)
-
         result = runner.invoke(cli, ["modify-tap", "--start-schema-at=1", TEST_YAML], catch_exceptions=False)
         self.assertEqual(result.exit_code, 0)
 


### PR DESCRIPTION
Add a default of 0 so that a TypeError does not occur when the "--start-schema-at" option is unspecified.