### PR TITLE
DM-42540: Check for duplicates when validating schema

### DIFF
--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -311,13 +311,13 @@ class SchemaTestCase(unittest.TestCase):
             Schema(name="testSchema", id="#test_id")
 
         test_col = Column(name="testColumn", id="#test_id", datatype="string")
-        test_tbl = Table(name="testTable", id="#test_id", columns=[test_col])
+        test_tbl = Table(name="testTable", id="#test_tbl_id", columns=[test_col])
 
         # Setting name, id, and columns should not throw an exception and
         # should load data correctly.
-        sch = Schema(name="testSchema", id="#test_id", tables=[test_tbl])
+        sch = Schema(name="testSchema", id="#test_sch_id", tables=[test_tbl])
         self.assertEqual(sch.name, "testSchema", "name should be 'testSchema'")
-        self.assertEqual(sch.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(sch.id, "#test_sch_id", "id should be '#test_id'")
         self.assertEqual(sch.tables, [test_tbl], "tables should be ['testTable']")
 
         # Creating a schema with duplicate table names should raise an


### PR DESCRIPTION
The Pydantic model was missing a check for duplicate IDs, which can lead to various errors when using other Felis modules such as tap. This will make a list of duplicates as they are found and then raise an error. The entire list will then be printed out after validation.

The error message will look like this:

```
ERROR:felis:1 validation error for Schema
  Value error, Duplicate IDs found in schema:
    #Object.g_deblend_fluxOverlap
    #Object.u_deblend_fluxOverlap
    #Object.y_deblend_fluxOverlap
    #Object.i_deblend_fluxOverlap
    #Object.r_deblend_fluxOverlap
    #Object.z_deblend_fluxOverlap
 [type=value_error, input_value={'name': 'ImsimSchema', '...its:tunit': 'pixel'}]}]}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.4/v/value_error
```