### PR TITLE
DM-42544: Add check for duplicate IDs when validating a schema

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -31,6 +31,19 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 logger = logging.getLogger(__name__)
 # logger.setLevel(logging.DEBUG)
 
+__all__ = (
+    "BaseObject",
+    "Column",
+    "Constraint",
+    "CheckConstraint",
+    "UniqueConstraint",
+    "Index",
+    "ForeignKeyConstraint",
+    "Table",
+    "SchemaVersion",
+    "Schema",
+)
+
 
 class BaseObject(BaseModel):
     """Base class for all Felis objects."""
@@ -299,33 +312,57 @@ class SchemaVersion(BaseModel):
     """The read compatible versions of the schema."""
 
 
-def _extract_ids(
-    obj: BaseModel | list[BaseModel] | dict[str, BaseModel], id_map: dict[str, BaseModel], processed: set[int]
-) -> None:
-    """Recursively extract ID values from a `BaseModel` object
-    and map them to their corresponding object.
+class SchemaVisitor:
+    """Visitor to build a Schema object's map of IDs to objects.
+
+    Duplicates are added to a set when they are encountered, which can be
+    accessed via the `duplicates` attribute. The presence of duplicates will
+    not throw an error. Only the first object with a given ID will be added to
+    the map, but this should not matter, since a ValidationError will be thrown
+    by the `model_validator` method if any duplicates are found in the schema.
+
+    This class is intended for internal use only.
     """
-    obj_id = id(obj)
-    if obj_id in processed:
-        return
-    processed.add(obj_id)
 
-    if isinstance(obj, BaseModel):
+    def __init__(self):
+        """Create a new SchemaVisitor."""
+        self.schema: "Schema" = None
+        self.duplicates: set[str] = set()
+
+    def add(self, obj: BaseObject):
+        """Add an object to the ID map."""
         if hasattr(obj, "id"):
-            id_map[getattr(obj, "id")] = obj
+            obj_id = getattr(obj, "id")
+            if obj_id in self.schema.id_map:
+                self.duplicates.add(obj_id)
+            else:
+                self.schema.id_map[obj_id] = obj
 
-        # Iterate over the fields of the BaseModel object
-        for attr, value in obj.__dict__.items():
-            if isinstance(value, BaseModel | list | dict):
-                _extract_ids(value, id_map, processed)
+    def visit_schema(self, schema: "Schema"):
+        """Visit a schema object.
 
-    elif isinstance(obj, list):
-        for item in obj:
-            _extract_ids(item, id_map, processed)
+        This will set an internal variable pointing to the schema object.
+        """
+        self.schema = schema
+        self.add(schema)
+        for table in schema.tables:
+            self.visit_table(table)
 
-    elif isinstance(obj, dict):
-        for value in obj.values():
-            _extract_ids(value, id_map, processed)
+    def visit_table(self, table: Table):
+        """Visit a table object."""
+        self.add(table)
+        for column in table.columns:
+            self.visit_column(column)
+        for constraint in table.constraints:
+            self.visit_constraint(constraint)
+
+    def visit_column(self, column: Column):
+        """Visit a column object."""
+        self.add(column)
+
+    def visit_constraint(self, constraint: Constraint):
+        """Visit a constraint object."""
+        self.add(constraint)
 
 
 class Schema(BaseObject):
@@ -351,6 +388,11 @@ class Schema(BaseObject):
     @model_validator(mode="after")
     def create_id_map(self) -> "Schema":
         """Create a map of IDs to objects."""
-        _extract_ids(self, self.id_map, set())
+        visitor: SchemaVisitor = SchemaVisitor()
+        visitor.visit_schema(self)
         logger.debug(f"ID map contains {len(self.id_map.keys())} objects")
+        if len(visitor.duplicates):
+            raise ValueError(
+                "Duplicate IDs found in schema:\n    " + "\n    ".join(visitor.duplicates) + "\n"
+            )
         return self

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -310,14 +310,14 @@ class SchemaTestCase(unittest.TestCase):
         with self.assertRaises(ValidationError):
             Schema(name="testSchema", id="#test_id")
 
-        test_col = Column(name="testColumn", id="#test_id", datatype="string")
-        test_tbl = Table(name="testTable", id="#test_id", columns=[test_col])
+        test_col = Column(name="testColumn", id="#test_col_id", datatype="string")
+        test_tbl = Table(name="testTable", id="#test_tbl_id", columns=[test_col])
 
         # Setting name, id, and columns should not throw an exception and
         # should load data correctly.
-        sch = Schema(name="testSchema", id="#test_id", tables=[test_tbl])
+        sch = Schema(name="testSchema", id="#test_sch_id", tables=[test_tbl])
         self.assertEqual(sch.name, "testSchema", "name should be 'testSchema'")
-        self.assertEqual(sch.id, "#test_id", "id should be '#test_id'")
+        self.assertEqual(sch.id, "#test_sch_id", "id should be '#test_sch_id'")
         self.assertEqual(sch.tables, [test_tbl], "tables should be ['testTable']")
 
         # Creating a schema with duplicate table names should raise an

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -329,16 +329,32 @@ class SchemaTestCase(unittest.TestCase):
         with self.assertRaises(ValidationError):
             Schema(**{"name": "testSchema", "id": "#test_sch_id", "bad_field": "1234"}, tables=[test_tbl])
 
+        # Creating a schema containing duplicate IDs should raise an error.
+        with self.assertRaises(ValidationError):
+            Schema(
+                name="testSchema",
+                id="#test_sch_id",
+                tables=[
+                    Table(
+                        name="testTable",
+                        id="#test_tbl_id",
+                        columns=[
+                            Column(name="testColumn", id="#test_col_id", datatype="string"),
+                            Column(name="testColumn2", id="#test_col_id", datatype="string"),
+                        ],
+                    )
+                ],
+            )
+
     def test_id_map(self) -> None:
         """Test that the id_map is properly populated."""
         test_col = Column(name="testColumn", id="#test_col_id", datatype="string")
         test_tbl = Table(name="testTable", id="#test_table_id", columns=[test_col])
         sch = Schema(name="testSchema", id="#test_schema_id", tables=[test_tbl])
 
-        # print(f"id map:\n {sch.id_map}")
-
         for id in ["#test_col_id", "#test_table_id", "#test_schema_id"]:
-            self.assertTrue(id in sch.id_map, f"ID {id} is missing from id_map")
+            # Test that the id_map contains the expected id.
+            sch.get_object_by_id(id)
 
 
 class SchemaVersionTest(unittest.TestCase):


### PR DESCRIPTION
The function for building a map of IDs to objects was rewritten using a visitor pattern, as the old version using recursion was prone to error and not working consistently. Duplicates are added to a set as the schema is visited. The `model_validator` function will throw an error if any duplicates are found, which will include a complete list of all the duplicate IDs. The new implementation of the ID builder and duplicate check was tested by running on several sdm_schemas which are known to contain duplicate IDs (imsim, hsc). These will be fixed in a different ticket branch on sdm_schemas.