### PR TITLE
DM-42446: Implement minor fixes and improvements to Python syntax

### DIFF
--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -19,12 +19,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import io
 import json
 import logging
 import sys
 from collections.abc import Iterable, Mapping, MutableMapping
-from typing import Any, Type
+from typing import Any
 
 import click
 import yaml
@@ -314,7 +316,7 @@ def merge(files: Iterable[io.TextIOBase]) -> None:
 @click.argument("files", nargs=-1, type=click.File())
 def validate(schema_name: str, require_description: bool, files: Iterable[io.TextIOBase]) -> None:
     """Validate one or more felis YAML files."""
-    schema_class: Type[Schema] = get_schema(schema_name)
+    schema_class = get_schema(schema_name)
     logger.info(f"Using schema '{schema_class.__name__}'")
 
     if require_description:

--- a/python/felis/utils.py
+++ b/python/felis/utils.py
@@ -19,6 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 from collections.abc import Iterable, Mapping, MutableMapping
 from typing import Any
 

--- a/python/felis/validation.py
+++ b/python/felis/validation.py
@@ -19,8 +19,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import logging
-from typing import Any, Sequence, Type
+from collections.abc import Sequence
+from typing import Any
 
 from pydantic import Field, model_validator
 
@@ -28,13 +31,14 @@ from .datamodel import DESCR_MIN_LENGTH, Column, Schema, Table
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["RspColumn", "RspSchema", "RspTable", "get_schema"]
+
 
 class RspColumn(Column):
     """Column for RSP data validation."""
 
     description: str = Field(..., min_length=DESCR_MIN_LENGTH)
-    """Redefine description to make it required and non-empty.
-    """
+    """Redefine description to make it required and non-empty."""
 
 
 class RspTable(Table):
@@ -93,7 +97,7 @@ class RspSchema(Schema):
         return sch
 
 
-def get_schema(schema_name: str) -> Type[Schema]:
+def get_schema(schema_name: str) -> type[Schema]:
     """Get the schema class for the given name."""
     if schema_name == "default":
         return Schema

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,11 +137,18 @@ class CliTestCase(unittest.TestCase):
     def test_validate_default_with_require_description(self) -> None:
         """Test validate command with description required."""
         runner = CliRunner()
-        result = runner.invoke(cli, ["validate", "--require-description", TEST_YAML], catch_exceptions=False)
-        # This state needs to be reset for subsequent tests or some will fail.
-        # This is not an issue when running the actual command line tool, which
-        # will execute in its own system process.
-        Schema.require_description(False)
+        try:
+            # Wrap this in a try/catch in case an exception is thrown.
+            result = runner.invoke(
+                cli, ["validate", "--require-description", TEST_YAML], catch_exceptions=False
+            )
+        except Exception as e:
+            # Reraise exception.
+            raise e
+        finally:
+            # Turn the flag off so it does not effect subsequent tests.
+            Schema.require_description(False)
+
         self.assertEqual(result.exit_code, 0)
 
     def test_validate_rsp(self) -> None:

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -121,7 +121,9 @@ class ColumnTestCase(unittest.TestCase):
         with self.assertRaises(ValidationError):
             Column(**units_data)
 
-        # Turn on description requirement for next two tests.
+    def test_require_description(self) -> None:
+        """Test the require_description flag for the `Column` class."""
+        # Turn on description requirement for this test.
         Schema.require_description(True)
 
         # Make sure that setting the flag for description requirement works
@@ -131,13 +133,27 @@ class ColumnTestCase(unittest.TestCase):
         # Creating a column without a description when required should throw an
         # error.
         with self.assertRaises(ValidationError):
-            col = Column(
+            Column(
                 **{
                     "name": "testColumn",
                     "@id": "#test_col_id",
                     "datatype": "string",
                 }
             )
+
+        # Creating a column with a None description when required should throw.
+        with self.assertRaises(ValidationError):
+            Column(**{"name": "testColumn", "@id": "#test_col_id", "datatype": "string", "description": None})
+
+        # Creating a column with an empty description when required should
+        # throw.
+        with self.assertRaises(ValidationError):
+            Column(**{"name": "testColumn", "@id": "#test_col_id", "datatype": "string", "description": ""})
+
+        # Creating a column with a description that is not long enough should
+        # throw.
+        with self.assertRaises(ValidationError):
+            Column(**{"name": "testColumn", "@id": "#test_col_id", "datatype": "string", "description": "xy"})
 
         # Turn off flag or it will affect subsequent tests.
         Schema.require_description(False)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -382,7 +382,7 @@ class SchemaTestCase(unittest.TestCase):
         self.assertIsInstance(sch["#test_table_id"], Table, "schema[id] should return a Table")
         self.assertIsInstance(sch["#test_schema_id"], Schema, "schema[id] should return a Schema")
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             # Test that an invalid id raises an exception.
             sch["#bad_id"]
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -47,6 +47,10 @@ class RSPSchemaTestCase(unittest.TestCase):
         with self.assertRaises(ValidationError):
             RspColumn(name="testColumn", id="#test_col_id", datatype="string", description=None)
 
+        # A column description which is not long enough should throw.
+        with self.assertRaises(ValidationError):
+            RspColumn(name="testColumn", id="#test_col_id", datatype="string", description="xy")
+
         # Creating a valid RSP column should not throw an exception.
         col = RspColumn(
             **{


### PR DESCRIPTION
This make changes suggested in review comments [here](https://github.com/lsst/felis/pull/31#pullrequestreview-1881543667
). The original PR was closed and merged before the second review occurred, so this is being done on a separate branch. All comments on the original PR should be resolved.

I made an additional change which was adding `from __future__ import annotations` to all of the Python files where it was missing.

I also added a few more simple tests in `test_datamodel.py` that check for various errors on the description field when the `require_description` flag is turned on.