### PR TITLE
Improve definition of description field

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from enum import Enum
-from typing import Any, Literal
+from typing import Annotated, Any, Literal, TypeAlias
 
 from astropy import units as units  # type: ignore
 from astropy.io.votable import ucd  # type: ignore
@@ -38,6 +38,7 @@ __all__ = (
     "Column",
     "CheckConstraint",
     "Constraint",
+    "DescriptionStr",
     "ForeignKeyConstraint",
     "Index",
     "Schema",
@@ -60,6 +61,10 @@ https://docs.pydantic.dev/2.0/api/config/#pydantic.config.ConfigDict
 DESCR_MIN_LENGTH = 3
 """Minimum length for a description field."""
 
+DescriptionStr: TypeAlias = Annotated[str, Field(min_length=DESCR_MIN_LENGTH)]
+"""Define a type for a description string, which must be three or more
+characters long. Stripping of whitespace is done globally on all str fields."""
+
 
 class BaseObject(BaseModel):
     """Base class for all Felis objects."""
@@ -79,7 +84,7 @@ class BaseObject(BaseModel):
     All Felis database objects must have a unique identifier.
     """
 
-    description: str | None = Field(None, min_length=DESCR_MIN_LENGTH)
+    description: DescriptionStr | None = None
     """A description of the database object.
 
     By default, the description is optional but will be required if

--- a/python/felis/validation.py
+++ b/python/felis/validation.py
@@ -27,7 +27,7 @@ from typing import Any
 
 from pydantic import Field, model_validator
 
-from .datamodel import DESCR_MIN_LENGTH, Column, Schema, Table
+from .datamodel import Column, DescriptionStr, Schema, Table
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,8 @@ __all__ = ["RspColumn", "RspSchema", "RspTable", "get_schema"]
 class RspColumn(Column):
     """Column for RSP data validation."""
 
-    description: str = Field(..., min_length=DESCR_MIN_LENGTH)
-    """Redefine description to make it required and non-empty."""
+    description: DescriptionStr
+    """Redefine description to make it required."""
 
 
 class RspTable(Table):
@@ -49,8 +49,8 @@ class RspTable(Table):
     Tables for the RSP must have a TAP table index and a valid description.
     """
 
-    description: str = Field(..., min_length=DESCR_MIN_LENGTH)
-    """Redefine description so that it is required."""
+    description: DescriptionStr
+    """Redefine description to make it required."""
 
     tap_table_index: int = Field(..., alias="tap:table_index")
     """Redefine the TAP_SCHEMA table index so that it is required."""
@@ -76,16 +76,12 @@ class RspSchema(Schema):
     TAP table indexes must be unique across all tables.
     """
 
-    description: str = Field(..., min_length=DESCR_MIN_LENGTH)
-    """Redefine description to make it required and non-empty.
-    """
-
     tables: Sequence[RspTable]
     """Redefine tables to include RSP validation."""
 
     @model_validator(mode="after")  # type: ignore[arg-type]
     @classmethod
-    def check_tap_table_indexes(cls: Any, sch: "RspSchema") -> "RspSchema":
+    def check_tap_table_indexes(cls: Any, sch: RspSchema) -> RspSchema:
         """Check that the TAP table indexes are unique."""
         table_indicies = set()
         for table in sch.tables:


### PR DESCRIPTION
Use Annotated along with TypeAlias to get rid of MyPy errors and improve how description strings are handled.