### PR TITLE
Resolve sqlalchemy deprecation warning

### DIFF
--- a/python/felis/tap.py
+++ b/python/felis/tap.py
@@ -30,8 +30,7 @@ from typing import Any
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.mock import MockConnection
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
 from sqlalchemy.schema import MetaData
 from sqlalchemy.sql.expression import Insert, insert
 


### PR DESCRIPTION
Import `declarative_base` from new module to resolve sqlalchemy deprecation warning.

Warning message was:

```
felis/tap.py:44: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
```