### PR TITLE
DM-42970: Use a custom function for printing validation errors

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -455,7 +455,7 @@ class Schema(BaseObject):
         Users should call this method to set the requirement for a description
         when validating schemas, rather than change the flag value directly.
         """
-        logger.debug(f"Setting description requirement to '{rd}'")
+        logger.debug(f"Setting description requirement to: {rd}")
         cls.ValidationConfig._require_description = rd
 
     @classmethod


### PR DESCRIPTION
The new function prints out the error location, message, and input data, omitting some information from the default printout which does not seem that useful to the end user.

TODO

- [ ] Add a test that will read a YAML schema containing many different types of errors and print them out.
- [ ] Include relevant input data for errors resulting from `field_validator` functions, like when a description is too short (Is this possible or would the checks need to be converted to `model_validator` instead?).