### PR TITLE
DM-41341: Use vounit format when validating units

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -195,7 +195,7 @@ class Column(BaseObject):
 
         if unit is not None:
             try:
-                units.Unit(unit)
+                units.Unit(unit, format="vounit", parse_strict="raise")
             except ValueError as e:
                 raise ValueError(f"Invalid unit: {e}")
 


### PR DESCRIPTION
This will apply stricter checks on units than the default. Also set parse_strict to always raise exceptions. This is the default, but make it clear in the validation function that this is the desired behavior when parsing column units.