### PR TITLE
DM-41247: Add tool that checks for redundant datatype definitions

### DIFF
--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -376,13 +376,26 @@ def merge(files: Iterable[io.TextIOBase]) -> None:
 @click.option(
     "-d", "--require-description", is_flag=True, help="Require description for all objects", default=False
 )
+@click.option(
+    "-t", "--check-redundant-datatypes", is_flag=True, help="Check for redundant datatypes", default=False
+)
 @click.argument("files", nargs=-1, type=click.File())
-def validate(schema_name: str, require_description: bool, files: Iterable[io.TextIOBase]) -> None:
+def validate(
+    schema_name: str,
+    require_description: bool,
+    check_redundant_datatypes: bool,
+    files: Iterable[io.TextIOBase],
+) -> None:
     """Validate one or more felis YAML files."""
     schema_class = get_schema(schema_name)
     logger.info(f"Using schema '{schema_class.__name__}'")
 
     schema_class.Config.require_description = require_description
+    if require_description:
+        logger.info("Requiring descriptions for all objects")
+    schema_class.Config.check_redundant_datatypes = check_redundant_datatypes
+    if check_redundant_datatypes:
+        logger.info("Checking for redundant datatypes")
 
     rc = 0
     for file in files:

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -382,7 +382,7 @@ def validate(schema_name: str, require_description: bool, files: Iterable[io.Tex
     schema_class = get_schema(schema_name)
     logger.info(f"Using schema '{schema_class.__name__}'")
 
-    schema_class.ValidationConfig.require_description = require_description
+    schema_class.Config.require_description = require_description
 
     rc = 0
     for file in files:

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -388,7 +388,8 @@ def validate(
 ) -> None:
     """Validate one or more felis YAML files."""
     schema_class = get_schema(schema_name)
-    logger.info(f"Using schema '{schema_class.__name__}'")
+    if schema_name != "default":
+        logger.info(f"Using schema '{schema_class.__name__}'")
 
     schema_class.Config.require_description = require_description
     if require_description:

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -373,15 +373,16 @@ def merge(files: Iterable[io.TextIOBase]) -> None:
     type=click.Choice(["RSP", "default"]),
     default="default",
 )
-@click.option("-d", "--require-description", is_flag=True, help="Require description for all objects")
+@click.option(
+    "-d", "--require-description", is_flag=True, help="Require description for all objects", default=False
+)
 @click.argument("files", nargs=-1, type=click.File())
 def validate(schema_name: str, require_description: bool, files: Iterable[io.TextIOBase]) -> None:
     """Validate one or more felis YAML files."""
     schema_class = get_schema(schema_name)
     logger.info(f"Using schema '{schema_class.__name__}'")
 
-    if require_description:
-        Schema.require_description(True)
+    schema_class.ValidationConfig.require_description = require_description
 
     rc = 0
     for file in files:

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -272,8 +272,13 @@ class Column(BaseObject):
 
         datatype_func = get_type_func(datatype)
         felis_type = FelisType.felis_type(datatype)
-        if felis_type.is_sized and length is not None:
-            datatype_obj = datatype_func(length)
+        if felis_type.is_sized:
+            if length is not None:
+                datatype_obj = datatype_func(length)
+            else:
+                raise ValueError(
+                    f"Length must be provided for sized type '{datatype}' in column '{values['@id']}'"
+                )
         else:
             datatype_obj = datatype_func()
 

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -520,8 +520,8 @@ class Schema(BaseObject):
         check_redundant_datatypes = False
         """Flag to enable checking for redundant datatypes on columns.
 
-        An example would be providing both 'mysql:datatype: DOUBLE' and
-        'datatype: DOUBLE' as MySQL would have used that type by default.
+        An example would be providing both ``mysql:datatype: DOUBLE`` and
+        ``datatype: double`` as MySQL would have used that type by default.
         """
 
     version: SchemaVersion | str | None = None

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -281,20 +281,13 @@ class Column(BaseObject):
             if f"{dialect_name}:datatype" in values:
                 datatype_string = values[f"{dialect_name}:datatype"]
                 db_datatype_obj = string_to_typeengine(datatype_string, dialect, length)
-                try:  # DEBUG
-                    print(f"datatype: {datatype_obj.compile(dialect)}")  # DEBUG
-                    print(f"{dialect_name}:datatype: {db_datatype_obj.compile(dialect)}")  # DEBUG
-                    if datatype_obj.compile(dialect) == db_datatype_obj.compile(dialect):
-                        print("Same type")
-                        raise ValueError(
-                            "'{}:datatype: {}' is the same as 'datatype: {}' in column '{}'".format(
-                                dialect_name, datatype_string, values["datatype"], values["@id"]
-                            )
+                if datatype_obj.compile(dialect) == db_datatype_obj.compile(dialect):
+                    raise ValueError(
+                        "'{}:datatype: {}' is the same as 'datatype: {}' in column '{}'".format(
+                            dialect_name, datatype_string, values["datatype"], values["@id"]
                         )
-                    else:  # DEBUG
-                        print("Different type")  # DEBUG
-                finally:  # DEBUG
-                    print()  # DEBUG
+                    )
+
         return values
 
 

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -496,7 +496,7 @@ class Schema(BaseObject):
         This is set by the `require_description` class method.
         """
 
-        check_redundant_datatypes = True
+        check_redundant_datatypes = False
         """Flag to enable checking for redundant datatypes on columns.
 
         An example would be providing both 'mysql:datatype: DOUBLE' and
@@ -524,7 +524,7 @@ class Schema(BaseObject):
     def create_id_map(self: Schema) -> Schema:
         """Create a map of IDs to objects."""
         if len(self.id_map):
-            logger.debug("ID map was already populated")
+            logger.debug("Ignoring call to create_id_map() - ID map was already populated")
             return self
         visitor: SchemaIdVisitor = SchemaIdVisitor()
         visitor.visit_schema(self)

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -287,6 +287,12 @@ class Column(BaseObject):
                             dialect_name, datatype_string, values["datatype"], values["@id"]
                         )
                     )
+                else:
+                    logger.debug(
+                        "'{}:datatype: {}' is a valid override of 'datatype: {}' in column '{}'".format(
+                            dialect_name, datatype_string, values["datatype"], values["@id"]
+                        )
+                    )
 
         return values
 

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -299,8 +299,13 @@ class Column(BaseObject):
                     )
                 else:
                     logger.debug(
-                        "'{}:datatype: {}' is a valid override of 'datatype: {}' in column '{}'".format(
-                            dialect_name, datatype_string, values["datatype"], values["@id"]
+                        "Valid type override of 'datatype: {}' with '{}:datatype: {}' in column '{}'".format(
+                            values["datatype"], dialect_name, datatype_string, values["@id"]
+                        )
+                    )
+                    logger.debug(
+                        "Compiled datatype '{}' with {} compiled override '{}'".format(
+                            datatype_obj.compile(dialect), dialect_name, db_datatype_obj.compile(dialect)
                         )
                     )
 

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -101,7 +101,7 @@ class BaseObject(BaseModel):
     @classmethod
     def check_description(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Check that the description is present if required."""
-        if Schema.ValidationConfig.require_description:
+        if Schema.Config.require_description:
             if "description" not in values or not values["description"]:
                 raise ValueError("Description is required and must be non-empty")
             if len(values["description"].strip()) < DESCR_MIN_LENGTH:
@@ -262,7 +262,7 @@ class Column(BaseObject):
     @classmethod
     def check_redundant_datatypes(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Check for redundant datatypes on columns."""
-        if not Schema.ValidationConfig.check_redundant_datatypes:
+        if not Schema.Config.check_redundant_datatypes:
             return values
         if all(f"{dialect}:datatype" not in values for dialect in _DIALECTS.keys()):
             return values
@@ -487,7 +487,7 @@ class SchemaIdVisitor:
 class Schema(BaseObject):
     """The database schema containing the tables."""
 
-    class ValidationConfig:
+    class Config:
         """Validation configuration which is specific to Felis."""
 
         require_description = False

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -93,7 +93,7 @@ class BaseObject(BaseModel):
     @classmethod
     def check_description(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Check that the description is present if required."""
-        if Schema.is_description_required():
+        if Schema.ValidationConfig.require_description:
             if "description" not in values or not values["description"]:
                 raise ValueError("Description is required and must be non-empty")
             if len(values["description"].strip()) < DESCR_MIN_LENGTH:
@@ -407,7 +407,7 @@ class Schema(BaseObject):
     class ValidationConfig:
         """Validation configuration which is specific to Felis."""
 
-        _require_description = False
+        require_description = False
         """Flag to require a description for all objects.
 
         This is set by the `require_description` class method.
@@ -454,20 +454,3 @@ class Schema(BaseObject):
     def __contains__(self, id: str) -> bool:
         """Check if an object with the given ID is in the schema."""
         return id in self.id_map
-
-    @classmethod
-    def require_description(cls, rd: bool = True) -> None:
-        """Set whether a description is required for all objects.
-
-        This includes the schema, tables, columns, and constraints.
-
-        Users should call this method to set the requirement for a description
-        when validating schemas, rather than change the flag value directly.
-        """
-        logger.debug(f"Setting description requirement to '{rd}'")
-        cls.ValidationConfig._require_description = rd
-
-    @classmethod
-    def is_description_required(cls) -> bool:
-        """Return whether a description is required for all objects."""
-        return cls.ValidationConfig._require_description

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -257,15 +257,14 @@ class Column(BaseObject):
             print(datatype_obj.compile())
             print(mysql_datatype_obj.compile(_MYSQL_DIALECT))
             if datatype_obj.compile() == mysql_datatype_obj.compile(_MYSQL_DIALECT):
-                print("Different type")
+                print("Same type\n")
                 raise ValueError(
                     "'mysql:datatype: {}' is the same as 'datatype: {}' in column '{}'".format(
                         values["mysql:datatype"], values["datatype"], values["@id"]
                     )
                 )
             else:
-                print("Same type")
-            print("")
+                print("Different type\n")
         return values
 
 

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -239,12 +239,11 @@ class Column(BaseObject):
 
         if "mysql:datatype" in values:
             mysql_datatype = values.get("mysql:datatype")
+            mysql_length = None
             if "(" in mysql_datatype:
                 mysql_length_match = re.search((r"\((\d+)\)"), mysql_datatype)
                 if mysql_length_match:
                     mysql_length = int(mysql_length_match.group(1))
-                else:
-                    mysql_length = None
                 mysql_datatype_match = re.match(r"([^\(]+)", mysql_datatype)
                 mysql_datatype = mysql_datatype_match.group(1)
             mysql_datatype_func = getattr(mysql, mysql_datatype, None)
@@ -254,9 +253,9 @@ class Column(BaseObject):
                 mysql_datatype_obj = mysql_datatype_func(length=mysql_length or length)
             else:
                 mysql_datatype_obj = mysql_datatype_func()
-            print(datatype_obj.compile())
+            print(datatype_obj.compile(_MYSQL_DIALECT))
             print(mysql_datatype_obj.compile(_MYSQL_DIALECT))
-            if datatype_obj.compile() == mysql_datatype_obj.compile(_MYSQL_DIALECT):
+            if datatype_obj.compile(_MYSQL_DIALECT) == mysql_datatype_obj.compile(_MYSQL_DIALECT):
                 print("Same type\n")
                 raise ValueError(
                     "'mysql:datatype: {}' is the same as 'datatype: {}' in column '{}'".format(

--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -21,9 +21,9 @@
 
 import builtins
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Callable
 
-from sqlalchemy import Float, SmallInteger, types
+from sqlalchemy import SmallInteger, types
 from sqlalchemy.dialects import mysql, oracle, postgresql
 from sqlalchemy.ext.compiler import compiles
 
@@ -39,22 +39,10 @@ class TINYINT(SmallInteger):
     __visit_name__ = "TINYINT"
 
 
-class DOUBLE(Float):
-    """The non-standard DOUBLE type."""
-
-    __visit_name__ = "DOUBLE"
-
-
 @compiles(TINYINT)
 def compile_tinyint(type_: Any, compiler: Any, **kw: Any) -> str:
     """Return type name for TINYINT."""
     return "TINYINT"
-
-
-@compiles(DOUBLE)
-def compile_double(type_: Any, compiler: Any, **kw: Any) -> str:
-    """Return type name for double precision type."""
-    return "DOUBLE"
 
 
 _TypeMap = Mapping[str, types.TypeEngine | type[types.TypeEngine]]
@@ -160,7 +148,7 @@ def float(**kwargs: Any) -> types.TypeEngine:
 
 def double(**kwargs: Any) -> types.TypeEngine:
     """Return SQLAlchemy type for double precision float."""
-    return _vary(DOUBLE(), double_map, kwargs)
+    return _vary(types.DOUBLE(), double_map, kwargs)
 
 
 def char(length: builtins.int, **kwargs: Any) -> types.TypeEngine:
@@ -191,6 +179,13 @@ def binary(length: builtins.int, **kwargs: Any) -> types.TypeEngine:
 def timestamp(**kwargs: Any) -> types.TypeEngine:
     """Return SQLAlchemy type for timestamp."""
     return types.TIMESTAMP()
+
+
+def get_type_func(type_name: str) -> Callable:
+    """Return the function for the type with the given name."""
+    if type_name not in globals():
+        raise ValueError(f"Unknown type: {type_name}")
+    return globals()[type_name]
 
 
 def _vary(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,7 +147,7 @@ class CliTestCase(unittest.TestCase):
             raise e
         finally:
             # Turn the flag off so it does not effect subsequent tests.
-            Schema.require_description(False)
+            Schema.ValidationConfig.require_description = False
 
         self.assertEqual(result.exit_code, 0)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,7 +147,7 @@ class CliTestCase(unittest.TestCase):
             raise e
         finally:
             # Turn the flag off so it does not effect subsequent tests.
-            Schema.ValidationConfig.require_description = False
+            Schema.Config.require_description = False
 
         self.assertEqual(result.exit_code, 0)
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -56,6 +56,12 @@ class DataModelTestCase(unittest.TestCase):
 class ColumnTestCase(unittest.TestCase):
     """Test the `Column` class."""
 
+    def setUp(self) -> None:
+        """Set up the test by turning off the description requirement in case
+        it was turned on by another test.
+        """
+        Schema.ValidationConfig.require_description = False
+
     def test_validation(self) -> None:
         """Test validation of the `Column` class."""
         # Default initialization should throw an exception.
@@ -124,11 +130,7 @@ class ColumnTestCase(unittest.TestCase):
     def test_require_description(self) -> None:
         """Test the require_description flag for the `Column` class."""
         # Turn on description requirement for this test.
-        Schema.require_description(True)
-
-        # Make sure that setting the flag for description requirement works
-        # correctly.
-        self.assertTrue(Schema.is_description_required(), "description should be required")
+        Schema.ValidationConfig.require_description = True
 
         # Creating a column without a description when required should throw an
         # error.
@@ -154,9 +156,6 @@ class ColumnTestCase(unittest.TestCase):
         # throw.
         with self.assertRaises(ValidationError):
             Column(**{"name": "testColumn", "@id": "#test_col_id", "datatype": "string", "description": "xy"})
-
-        # Turn off flag or it will affect subsequent tests.
-        Schema.require_description(False)
 
 
 class ConstraintTestCase(unittest.TestCase):

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -60,7 +60,7 @@ class ColumnTestCase(unittest.TestCase):
         """Set up the test by turning off the description requirement in case
         it was turned on by another test.
         """
-        Schema.ValidationConfig.require_description = False
+        Schema.Config.require_description = False
 
     def test_validation(self) -> None:
         """Test validation of the `Column` class."""
@@ -130,7 +130,7 @@ class ColumnTestCase(unittest.TestCase):
     def test_require_description(self) -> None:
         """Test the require_description flag for the `Column` class."""
         # Turn on description requirement for this test.
-        Schema.ValidationConfig.require_description = True
+        Schema.Config.require_description = True
 
         # Creating a column without a description when required should throw an
         # error.

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -51,7 +51,7 @@ class RedundantDatatypesTest(unittest.TestCase):
 
     def test_mysql_datatypes(self) -> None:
         """Test that redundant datatype definitions raise an error."""
-        Schema.ValidationConfig.check_redundant_datatypes = True
+        Schema.Config.check_redundant_datatypes = True
 
         coldata = ColumnGenerator("test_col", "#test_col_id", "mysql")
 
@@ -113,7 +113,7 @@ class RedundantDatatypesTest(unittest.TestCase):
             coldata.col("unicode", "CHAR", length=32)
 
         finally:
-            Schema.ValidationConfig.check_redundant_datatypes = False
+            Schema.Config.check_redundant_datatypes = False
 
 
 if __name__ == "__main__":

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1,0 +1,109 @@
+# This file is part of felis.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+from pydantic import ValidationError
+
+from felis.datamodel import Column, Schema
+
+
+def _col_mysql(datatype, mysql_datatype, length=None) -> dict[str, str]:
+    return Column(
+        **{
+            "name": "test_col",
+            "@id": "#test_col_id",
+            "datatype": datatype,
+            "mysql:datatype": mysql_datatype,
+            "length": length,
+        }
+    )
+
+
+class RedaundantDatatypesTest(unittest.TestCase):
+    """Test validation of redundant datatype definitions."""
+
+    def test_mysql_datatypes(self) -> None:
+        """Test that redundant datatype definitions raise an error."""
+        Schema.ValidationConfig.check_redundant_datatypes = True
+        try:
+            # Error: same type
+            with self.assertRaises(ValidationError):
+                _col_mysql("double", "DOUBLE")
+
+            # Error: same type
+            with self.assertRaises(ValidationError):
+                _col_mysql("int", "INTEGER")
+
+            # Error: same type
+            with self.assertRaises(ValidationError):
+                _col_mysql("float", "FLOAT")
+
+            # Error: same type
+            with self.assertRaises(ValidationError):
+                _col_mysql("char", "CHAR", length=8)
+
+            # Error: same type
+            with self.assertRaises(ValidationError):
+                _col_mysql("string", "VARCHAR", length=32)
+
+            # Error: same type mapping as default
+            with self.assertRaises(ValidationError):
+                _col_mysql("byte", "TINYINT")
+
+            # Error: same type mapping as default
+            with self.assertRaises(ValidationError):
+                _col_mysql("short", "SMALLINT")
+
+            # Error: same type mapping as default
+            with self.assertRaises(ValidationError):
+                _col_mysql("long", "BIGINT")
+
+            # Okay: These look equivalent but default is actually `BIT(1)`.
+            _col_mysql("boolean", "BOOLEAN")
+
+            # TODO:
+            # - unicode
+            # - text
+            # - binary
+            # - timestamp
+
+            # Fixme: This should raise an error but MySQL type comes back as
+            # 'BIT' and not 'BIT(1)'.
+            # with self.assertRaises(ValidationError):
+            #    _col_mysql("boolean", "BIT(1)")
+
+            # Error: same type and length
+            with self.assertRaises(ValidationError):
+                _col_mysql("string", "VARCHAR(128)", length=128)
+
+            # Okay: different types
+            _col_mysql("double", "FLOAT")
+
+            # Okay: same base types with different lengths
+            _col_mysql("string", "VARCHAR(128)", length=32)
+
+        finally:
+            Schema.ValidationConfig.check_redundant_datatypes = False
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds a Pydantic validator that will identity variant type overrides, e.g., `mysql:datatype` values, that appear to be redundant. To determine whether the datatypes are the same, they are each compiled to a SQL snippet. If the resultant SQL is identical, then the type override is considered to be superfluous and an error is raised.

The validation needs to be turned on using the `-t/--check-redundant-datatypes` flag when running the `validate` command.