### PR TITLE
DM-43097: Improve support of TEXT type

### DIFF
--- a/python/felis/db/_variants.py
+++ b/python/felis/db/_variants.py
@@ -40,10 +40,10 @@ TABLE_OPTS = {
 }
 
 COLUMN_VARIANT_OVERRIDE = {
-    "mysql:datatype": "mysql",
-    "oracle:datatype": "oracle",
-    "postgresql:datatype": "postgresql",
-    "sqlite:datatype": "sqlite",
+    "mysql_datatype": "mysql",
+    "oracle_datatype": "oracle",
+    "postgresql_datatype": "postgresql",
+    "sqlite_datatype": "sqlite",
 }
 
 DIALECT_MODULES = {MYSQL: mysql, ORACLE: oracle, SQLITE: sqlite, POSTGRES: postgresql}
@@ -87,7 +87,7 @@ def make_variant_dict(column_obj: Column) -> dict[str, TypeEngine[Any]]:
     """
     variant_dict = {}
     for field_name, value in iter(column_obj):
-        if field_name in COLUMN_VARIANT_OVERRIDE:
+        if field_name in COLUMN_VARIANT_OVERRIDE and value is not None:
             dialect = COLUMN_VARIANT_OVERRIDE[field_name]
             variant: TypeEngine = process_variant_override(dialect, value)
             variant_dict[dialect] = variant

--- a/tests/data/sales.yaml
+++ b/tests/data/sales.yaml
@@ -70,7 +70,7 @@ tables:
         "@id": "#items.item_id"
         datatype: int
         description: Unique item identifier
-        mysql:datatype: INT
+        mysql:datatype: INTEGER
         tap:principal: 1
       - name: order_id
         "@id": "#items.order_id"


### PR DESCRIPTION
Felis insists that `text` datatype is sized and required `length` to be specified. But it maps `text` to MySQL `LONGTEXT` and PostgreSQL `TEXT` types which do not accept length specification. This patch adds a workaround for those two types which drops length argument. A unit test was added as well to trigger various cases for `text` and other sized types

`tests/data/sales.yaml` specified mysql datatype override as `INT` which does not exist (in sqlalchemy at least), it needs to be `INTEGER`.