### PR TITLE
DM-43097: Make text type un-sized

### DIFF
--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -178,9 +178,9 @@ def unicode(length: builtins.int, **kwargs: Any) -> types.TypeEngine:
     return _vary(types.NVARCHAR(length), unicode_map, kwargs, length)
 
 
-def text(length: builtins.int, **kwargs: Any) -> types.TypeEngine:
+def text(**kwargs: Any) -> types.TypeEngine:
     """Return SQLAlchemy type for text."""
-    return _vary(types.CLOB(length), text_map, kwargs, length)
+    return _vary(types.TEXT(), text_map, kwargs)
 
 
 def binary(length: builtins.int, **kwargs: Any) -> types.TypeEngine:

--- a/python/felis/types.py
+++ b/python/felis/types.py
@@ -125,7 +125,7 @@ class Unicode(FelisType, felis_name="unicode", votable_name="unicodeChar", is_si
     """Felis definition of unicode string type."""
 
 
-class Text(FelisType, felis_name="text", votable_name="unicodeChar", is_sized=True):
+class Text(FelisType, felis_name="text", votable_name="unicodeChar"):
     """Felis definition of text type."""
 
 

--- a/tests/data/sales.yaml
+++ b/tests/data/sales.yaml
@@ -52,6 +52,10 @@ tables:
         "@id": "#orders.order_date"
         datatype: timestamp
         description: Order date
+      - name: special_instructions
+        "@id": "#orders.special_instructions"
+        datatype: text
+        description: Special instructions
     constraints:
       - name: fk_customer_id
         "@id": "#orders_fk_customer_id"
@@ -70,7 +74,6 @@ tables:
         "@id": "#items.item_id"
         datatype: int
         description: Unique item identifier
-        mysql:datatype: INT
         tap:principal: 1
       - name: order_id
         "@id": "#items.order_id"


### PR DESCRIPTION
This changes the Felis `text` type to be un-sized, since `length` should not be required.