### PR TITLE
DM-42257: Make the text type un-sized so length is not required

### DIFF
--- a/python/felis/db/_variants.py
+++ b/python/felis/db/_variants.py
@@ -40,10 +40,10 @@ TABLE_OPTS = {
 }
 
 COLUMN_VARIANT_OVERRIDE = {
-    "mysql:datatype": "mysql",
-    "oracle:datatype": "oracle",
-    "postgresql:datatype": "postgresql",
-    "sqlite:datatype": "sqlite",
+    "mysql_datatype": "mysql",
+    "oracle_datatype": "oracle",
+    "postgresql_datatype": "postgresql",
+    "sqlite_datatype": "sqlite",
 }
 
 DIALECT_MODULES = {MYSQL: mysql, ORACLE: oracle, SQLITE: sqlite, POSTGRES: postgresql}
@@ -87,7 +87,7 @@ def make_variant_dict(column_obj: Column) -> dict[str, TypeEngine[Any]]:
     """
     variant_dict = {}
     for field_name, value in iter(column_obj):
-        if field_name in COLUMN_VARIANT_OVERRIDE:
+        if field_name in COLUMN_VARIANT_OVERRIDE and value is not None:
             dialect = COLUMN_VARIANT_OVERRIDE[field_name]
             variant: TypeEngine = process_variant_override(dialect, value)
             variant_dict[dialect] = variant

--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -198,7 +198,7 @@ def _vary(
     variants.update(overrides)
     for dialect, variant in variants.items():
         # If this is a class and not an instance, instantiate
-        if isinstance(variant, type):
+        if callable(variant):
             variant = variant(*args)
         type_ = type_.with_variant(variant, dialect)
     return type_

--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -166,9 +166,9 @@ def unicode(length: builtins.int, **kwargs: Any) -> types.TypeEngine:
     return _vary(types.NVARCHAR(length), unicode_map, kwargs, length)
 
 
-def text(length: builtins.int, **kwargs: Any) -> types.TypeEngine:
+def text(**kwargs: Any) -> types.TypeEngine:
     """Return SQLAlchemy type for text."""
-    return _vary(types.CLOB(length), text_map, kwargs, length)
+    return _vary(types.TEXT(), text_map, kwargs)
 
 
 def binary(length: builtins.int, **kwargs: Any) -> types.TypeEngine:

--- a/python/felis/types.py
+++ b/python/felis/types.py
@@ -125,7 +125,7 @@ class Unicode(FelisType, felis_name="unicode", votable_name="unicodeChar", is_si
     """Felis definition of unicode string type."""
 
 
-class Text(FelisType, felis_name="text", votable_name="unicodeChar", is_sized=True):
+class Text(FelisType, felis_name="text", votable_name="unicodeChar"):
     """Felis definition of text type."""
 
 

--- a/python/felis/types.py
+++ b/python/felis/types.py
@@ -125,7 +125,7 @@ class Unicode(FelisType, felis_name="unicode", votable_name="unicodeChar", is_si
     """Felis definition of unicode string type."""
 
 
-class Text(FelisType, felis_name="text", votable_name="unicodeChar"):
+class Text(FelisType, felis_name="text", votable_name="char"):
     """Felis definition of text type."""
 
 

--- a/tests/data/sales.yaml
+++ b/tests/data/sales.yaml
@@ -70,8 +70,6 @@ tables:
         "@id": "#items.item_id"
         datatype: int
         description: Unique item identifier
-        mysql:datatype: INT
-        tap:principal: 1
       - name: order_id
         "@id": "#items.order_id"
         datatype: int


### PR DESCRIPTION
The length should not be required when defining a text column, since it represents an unbounded string. The `is_sized` flag in Felis forces a column with that type to require a length, which we do not want for this datatype.