### PR TITLE
DM-41247: Implement redundant data type checking with fix for global validation state

### DIFF
--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -391,19 +391,19 @@ def validate(
     if schema_name != "default":
         logger.info(f"Using schema '{schema_class.__name__}'")
 
-    schema_class.Config.require_description = require_description
-    if require_description:
-        logger.info("Requiring descriptions for all objects")
-    schema_class.Config.check_redundant_datatypes = check_redundant_datatypes
-    if check_redundant_datatypes:
-        logger.info("Checking for redundant datatypes")
-
     rc = 0
     for file in files:
         file_name = getattr(file, "name", None)
         logger.info(f"Validating {file_name}")
         try:
-            schema_class.model_validate(yaml.load(file, Loader=yaml.SafeLoader))
+            data = yaml.load(file, Loader=yaml.SafeLoader)
+            schema_class.model_validate(
+                data,
+                context={
+                    "check_redundant_datatypes": check_redundant_datatypes,
+                    "require_description": require_description,
+                },
+            )
         except ValidationError as e:
             logger.error(e)
             rc = 1

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -373,15 +373,30 @@ def merge(files: Iterable[io.TextIOBase]) -> None:
     type=click.Choice(["RSP", "default"]),
     default="default",
 )
-@click.option("-d", "--require-description", is_flag=True, help="Require description for all objects")
+@click.option(
+    "-d", "--require-description", is_flag=True, help="Require description for all objects", default=False
+)
+@click.option(
+    "-t", "--check-redundant-datatypes", is_flag=True, help="Check for redundant datatypes", default=False
+)
 @click.argument("files", nargs=-1, type=click.File())
-def validate(schema_name: str, require_description: bool, files: Iterable[io.TextIOBase]) -> None:
+def validate(
+    schema_name: str,
+    require_description: bool,
+    check_redundant_datatypes: bool,
+    files: Iterable[io.TextIOBase],
+) -> None:
     """Validate one or more felis YAML files."""
     schema_class = get_schema(schema_name)
-    logger.info(f"Using schema '{schema_class.__name__}'")
+    if schema_name != "default":
+        logger.info(f"Using schema '{schema_class.__name__}'")
 
+    schema_class.Config.require_description = require_description
     if require_description:
-        Schema.require_description(True)
+        logger.info("Requiring descriptions for all objects")
+    schema_class.Config.check_redundant_datatypes = check_redundant_datatypes
+    if check_redundant_datatypes:
+        logger.info("Checking for redundant datatypes")
 
     rc = 0
     for file in files:

--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -21,9 +21,9 @@
 
 import builtins
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, Callable
 
-from sqlalchemy import Float, SmallInteger, types
+from sqlalchemy import SmallInteger, types
 from sqlalchemy.dialects import mysql, oracle, postgresql
 from sqlalchemy.ext.compiler import compiles
 
@@ -39,22 +39,10 @@ class TINYINT(SmallInteger):
     __visit_name__ = "TINYINT"
 
 
-class DOUBLE(Float):
-    """The non-standard DOUBLE type."""
-
-    __visit_name__ = "DOUBLE"
-
-
 @compiles(TINYINT)
 def compile_tinyint(type_: Any, compiler: Any, **kw: Any) -> str:
     """Return type name for TINYINT."""
     return "TINYINT"
-
-
-@compiles(DOUBLE)
-def compile_double(type_: Any, compiler: Any, **kw: Any) -> str:
-    """Return type name for double precision type."""
-    return "DOUBLE"
 
 
 _TypeMap = Mapping[str, types.TypeEngine | type[types.TypeEngine]]
@@ -160,7 +148,7 @@ def float(**kwargs: Any) -> types.TypeEngine:
 
 def double(**kwargs: Any) -> types.TypeEngine:
     """Return SQLAlchemy type for double precision float."""
-    return _vary(DOUBLE(), double_map, kwargs)
+    return _vary(types.DOUBLE(), double_map, kwargs)
 
 
 def char(length: builtins.int, **kwargs: Any) -> types.TypeEngine:
@@ -191,6 +179,13 @@ def binary(length: builtins.int, **kwargs: Any) -> types.TypeEngine:
 def timestamp(**kwargs: Any) -> types.TypeEngine:
     """Return SQLAlchemy type for timestamp."""
     return types.TIMESTAMP()
+
+
+def get_type_func(type_name: str) -> Callable:
+    """Return the function for the type with the given name."""
+    if type_name not in globals():
+        raise ValueError(f"Unknown type: {type_name}")
+    return globals()[type_name]
 
 
 def _vary(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,7 +147,7 @@ class CliTestCase(unittest.TestCase):
             raise e
         finally:
             # Turn the flag off so it does not effect subsequent tests.
-            Schema.require_description(False)
+            Schema.Config.require_description = False
 
         self.assertEqual(result.exit_code, 0)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,6 @@ from typing import Any
 from click.testing import CliRunner
 
 from felis.cli import cli
-from felis.datamodel import Schema
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 TEST_YAML = os.path.join(TESTDIR, "data", "test.yml")
@@ -145,9 +144,6 @@ class CliTestCase(unittest.TestCase):
         except Exception as e:
             # Reraise exception.
             raise e
-        finally:
-            # Turn the flag off so it does not effect subsequent tests.
-            Schema.Config.require_description = False
 
         self.assertEqual(result.exit_code, 0)
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -123,59 +123,74 @@ class ColumnTestCase(unittest.TestCase):
 
     def test_require_description(self) -> None:
         """Test the require_description flag for the `Column` class."""
-        # Creating a column without a description when required should throw an
-        # error.
-        with self.assertRaises(ValidationError):
-            Column(
-                **{
-                    "name": "testColumn",
-                    "@id": "#test_col_id",
-                    "datatype": "string",
-                    "require_description": True,
-                }
+
+        class MockValidationInfo:
+            """Mock context object for passing to validation method."""
+
+            def __init__(self):
+                self.context = {"require_description": True}
+
+        info = MockValidationInfo()
+
+        def _check_description(col: Column):
+            Schema.check_description(col, info)
+
+        # Creating a column without a description should throw.
+        with self.assertRaises(ValueError):
+            _check_description(
+                Column(
+                    **{
+                        "name": "testColumn",
+                        "@id": "#test_col_id",
+                        "datatype": "string",
+                    }
+                )
             )
 
-        # Creating a column with a None description when required should throw.
-        with self.assertRaises(ValidationError):
-            Column(
-                **{
-                    "name": "testColumn",
-                    "@id": "#test_col_id",
-                    "datatype": "string",
-                    "require_description": True,
-                    "description": None,
-                }
+        # Creating a column with a description of 'None' should throw.
+        with self.assertRaises(ValueError):
+            _check_description(
+                Column(
+                    **{
+                        "name": "testColumn",
+                        "@id": "#test_col_id",
+                        "datatype": "string",
+                        "description": None,
+                    }
+                )
             )
 
-        # Creating a column with an empty description when required should
-        # throw.
-        with self.assertRaises(ValidationError):
-            Column(
-                **{
-                    "name": "testColumn",
-                    "@id": "#test_col_id",
-                    "datatype": "string",
-                    "require_description": True,
-                    "description": "",
-                }
+        # Creating a column with an empty description should throw.
+        with self.assertRaises(ValueError):
+            _check_description(
+                Column(
+                    **{
+                        "name": "testColumn",
+                        "@id": "#test_col_id",
+                        "datatype": "string",
+                        "require_description": True,
+                        "description": "",
+                    }
+                )
             )
 
-        # Creating a column with a description that is not long enough should
-        # throw.
+        # Creating a column with a description that is too short should throw.
         with self.assertRaises(ValidationError):
-            Column(
-                **{
-                    "name": "testColumn",
-                    "@id": "#test_col_id",
-                    "datatype": "string",
-                    "require_description": True,
-                    "description": "xy",
-                }
+            _check_description(
+                Column(
+                    **{
+                        "name": "testColumn",
+                        "@id": "#test_col_id",
+                        "datatype": "string",
+                        "require_description": True,
+                        "description": "xy",
+                    }
+                )
             )
 
 
 class ConstraintTestCase(unittest.TestCase):
-    """Test the `UniqueConstraint`, `Index`, `CheckCosntraint`, and
+    """Test the `UniqueConstraint`, `Index`, `CheckConstraint`, and
     `ForeignKeyConstraint` classes.
     """
 

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -56,6 +56,12 @@ class DataModelTestCase(unittest.TestCase):
 class ColumnTestCase(unittest.TestCase):
     """Test the `Column` class."""
 
+    def setUp(self) -> None:
+        """Set up the test by turning off the description requirement in case
+        it was turned on by another test.
+        """
+        Schema.Config.require_description = False
+
     def test_validation(self) -> None:
         """Test validation of the `Column` class."""
         # Default initialization should throw an exception.
@@ -124,11 +130,7 @@ class ColumnTestCase(unittest.TestCase):
     def test_require_description(self) -> None:
         """Test the require_description flag for the `Column` class."""
         # Turn on description requirement for this test.
-        Schema.require_description(True)
-
-        # Make sure that setting the flag for description requirement works
-        # correctly.
-        self.assertTrue(Schema.is_description_required(), "description should be required")
+        Schema.Config.require_description = True
 
         # Creating a column without a description when required should throw an
         # error.
@@ -154,9 +156,6 @@ class ColumnTestCase(unittest.TestCase):
         # throw.
         with self.assertRaises(ValidationError):
             Column(**{"name": "testColumn", "@id": "#test_col_id", "datatype": "string", "description": "xy"})
-
-        # Turn off flag or it will affect subsequent tests.
-        Schema.require_description(False)
 
 
 class ConstraintTestCase(unittest.TestCase):

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -56,12 +56,6 @@ class DataModelTestCase(unittest.TestCase):
 class ColumnTestCase(unittest.TestCase):
     """Test the `Column` class."""
 
-    def setUp(self) -> None:
-        """Set up the test by turning off the description requirement in case
-        it was turned on by another test.
-        """
-        Schema.Config.require_description = False
-
     def test_validation(self) -> None:
         """Test validation of the `Column` class."""
         # Default initialization should throw an exception.
@@ -81,14 +75,14 @@ class ColumnTestCase(unittest.TestCase):
         col = Column(name="testColumn", id="#test_id", datatype="string")
         self.assertEqual(col.name, "testColumn", "name should be 'testColumn'")
         self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
-        self.assertEqual(col.datatype, DataType.STRING, "datatype should be 'DataType.STRING'")
+        self.assertEqual(col.datatype, DataType.string, "datatype should be 'DataType.string'")
 
         # Creating from data dictionary should work and load data correctly.
         data = {"name": "testColumn", "id": "#test_id", "datatype": "string"}
         col = Column(**data)
         self.assertEqual(col.name, "testColumn", "name should be 'testColumn'")
         self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
-        self.assertEqual(col.datatype, DataType.STRING, "datatype should be 'DataType.STRING'")
+        self.assertEqual(col.datatype, DataType.string, "datatype should be 'DataType.string'")
 
         # Setting a bad IVOA UCD should throw an error.
         with self.assertRaises(ValidationError):
@@ -129,9 +123,6 @@ class ColumnTestCase(unittest.TestCase):
 
     def test_require_description(self) -> None:
         """Test the require_description flag for the `Column` class."""
-        # Turn on description requirement for this test.
-        Schema.Config.require_description = True
-
         # Creating a column without a description when required should throw an
         # error.
         with self.assertRaises(ValidationError):
@@ -140,22 +131,47 @@ class ColumnTestCase(unittest.TestCase):
                     "name": "testColumn",
                     "@id": "#test_col_id",
                     "datatype": "string",
+                    "require_description": True,
                 }
             )
 
         # Creating a column with a None description when required should throw.
         with self.assertRaises(ValidationError):
-            Column(**{"name": "testColumn", "@id": "#test_col_id", "datatype": "string", "description": None})
+            Column(
+                **{
+                    "name": "testColumn",
+                    "@id": "#test_col_id",
+                    "datatype": "string",
+                    "require_description": True,
+                    "description": None,
+                }
+            )
 
         # Creating a column with an empty description when required should
         # throw.
         with self.assertRaises(ValidationError):
-            Column(**{"name": "testColumn", "@id": "#test_col_id", "datatype": "string", "description": ""})
+            Column(
+                **{
+                    "name": "testColumn",
+                    "@id": "#test_col_id",
+                    "datatype": "string",
+                    "require_description": True,
+                    "description": "",
+                }
+            )
 
         # Creating a column with a description that is not long enough should
         # throw.
         with self.assertRaises(ValidationError):
-            Column(**{"name": "testColumn", "@id": "#test_col_id", "datatype": "string", "description": "xy"})
+            Column(
+                **{
+                    "name": "testColumn",
+                    "@id": "#test_col_id",
+                    "datatype": "string",
+                    "require_description": True,
+                    "description": "xy",
+                }
+            )
 
 
 class ConstraintTestCase(unittest.TestCase):

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1,0 +1,120 @@
+# This file is part of felis.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+from pydantic import ValidationError
+
+from felis.datamodel import Column, Schema
+
+
+class ColumnGenerator:
+    """Generate column data for testing."""
+
+    def __init__(self, name, id, db_name):
+        self.name = name
+        self.id = id
+        self.db_name = db_name
+
+    def col(self, datatype: str, db_datatype: str, length=None):
+        return Column(
+            **{
+                "name": self.name,
+                "@id": self.id,
+                "datatype": datatype,
+                f"{self.db_name}:datatype": db_datatype,
+                "length": length,
+            }
+        )
+
+
+class RedundantDatatypesTest(unittest.TestCase):
+    """Test validation of redundant datatype definitions."""
+
+    def test_mysql_datatypes(self) -> None:
+        """Test that redundant datatype definitions raise an error."""
+        Schema.Config.check_redundant_datatypes = True
+
+        coldata = ColumnGenerator("test_col", "#test_col_id", "mysql")
+
+        try:
+            with self.assertRaises(ValidationError):
+                coldata.col("double", "DOUBLE")
+
+            with self.assertRaises(ValidationError):
+                coldata.col("int", "INTEGER")
+
+            with self.assertRaises(ValidationError):
+                coldata.col("boolean", "BIT(1)")
+
+            with self.assertRaises(ValidationError):
+                coldata.col("float", "FLOAT")
+
+            with self.assertRaises(ValidationError):
+                coldata.col("char", "CHAR", length=8)
+
+            with self.assertRaises(ValidationError):
+                coldata.col("string", "VARCHAR", length=32)
+
+            with self.assertRaises(ValidationError):
+                coldata.col("byte", "TINYINT")
+
+            with self.assertRaises(ValidationError):
+                coldata.col("short", "SMALLINT")
+
+            with self.assertRaises(ValidationError):
+                coldata.col("long", "BIGINT")
+
+            # These look equivalent but default is actually ``BIT(1)``.
+            coldata.col("boolean", "BOOLEAN")
+
+            with self.assertRaises(ValidationError):
+                coldata.col("unicode", "NVARCHAR", length=32)
+
+            with self.assertRaises(ValidationError):
+                coldata.col("timestamp", "TIMESTAMP")
+
+            # DM-42257: Felis does not handle unbounded text types properly.
+            # coldata.col("text", "TEXT", length=32)
+
+            with self.assertRaises(ValidationError):
+                coldata.col("binary", "LONGBLOB", length=1024)
+
+            with self.assertRaises(ValidationError):
+                # Same type and length
+                coldata.col("string", "VARCHAR(128)", length=128)
+
+            # Different types, which is okay
+            coldata.col("double", "FLOAT")
+
+            # Same base type with different lengths, which is okay
+            coldata.col("string", "VARCHAR(128)", length=32)
+
+            # Different string types, which is okay
+            coldata.col("string", "CHAR", length=32)
+            coldata.col("unicode", "CHAR", length=32)
+
+        finally:
+            Schema.Config.check_redundant_datatypes = False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -82,7 +82,8 @@ class RedundantDatatypesTest(unittest.TestCase):
         with self.assertRaises(ValidationError):
             coldata.col("long", "BIGINT")
 
-        # These look like they should be equivalent, but the default is actually ``BIT(1)`` for MySQL.
+        # These look like they should be equivalent, but the default is
+        # actually ``BIT(1)`` for MySQL.
         coldata.col("boolean", "BOOLEAN")
 
         with self.assertRaises(ValidationError):

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -23,7 +23,7 @@ import unittest
 
 from pydantic import ValidationError
 
-from felis.datamodel import Column, Schema
+from felis.datamodel import Column
 
 
 class ColumnGenerator:
@@ -33,16 +33,18 @@ class ColumnGenerator:
         self.name = name
         self.id = id
         self.db_name = db_name
+        self.context = {"check_redundant_datatypes": True}
 
     def col(self, datatype: str, db_datatype: str, length=None):
-        return Column(
-            **{
+        return Column.model_validate(
+            {
                 "name": self.name,
                 "@id": self.id,
                 "datatype": datatype,
                 f"{self.db_name}:datatype": db_datatype,
                 "length": length,
-            }
+            },
+            context=self.context,
         )
 
 
@@ -51,69 +53,63 @@ class RedundantDatatypesTest(unittest.TestCase):
 
     def test_mysql_datatypes(self) -> None:
         """Test that redundant datatype definitions raise an error."""
-        Schema.Config.check_redundant_datatypes = True
-
         coldata = ColumnGenerator("test_col", "#test_col_id", "mysql")
 
-        try:
-            with self.assertRaises(ValidationError):
-                coldata.col("double", "DOUBLE")
+        with self.assertRaises(ValidationError):
+            coldata.col("double", "DOUBLE")
 
-            with self.assertRaises(ValidationError):
-                coldata.col("int", "INTEGER")
+        with self.assertRaises(ValidationError):
+            coldata.col("int", "INTEGER")
 
-            with self.assertRaises(ValidationError):
-                coldata.col("boolean", "BIT(1)")
+        with self.assertRaises(ValidationError):
+            coldata.col("boolean", "BIT(1)")
 
-            with self.assertRaises(ValidationError):
-                coldata.col("float", "FLOAT")
+        with self.assertRaises(ValidationError):
+            coldata.col("float", "FLOAT")
 
-            with self.assertRaises(ValidationError):
-                coldata.col("char", "CHAR", length=8)
+        with self.assertRaises(ValidationError):
+            coldata.col("char", "CHAR", length=8)
 
-            with self.assertRaises(ValidationError):
-                coldata.col("string", "VARCHAR", length=32)
+        with self.assertRaises(ValidationError):
+            coldata.col("string", "VARCHAR", length=32)
 
-            with self.assertRaises(ValidationError):
-                coldata.col("byte", "TINYINT")
+        with self.assertRaises(ValidationError):
+            coldata.col("byte", "TINYINT")
 
-            with self.assertRaises(ValidationError):
-                coldata.col("short", "SMALLINT")
+        with self.assertRaises(ValidationError):
+            coldata.col("short", "SMALLINT")
 
-            with self.assertRaises(ValidationError):
-                coldata.col("long", "BIGINT")
+        with self.assertRaises(ValidationError):
+            coldata.col("long", "BIGINT")
 
-            # These look equivalent but default is actually ``BIT(1)``.
-            coldata.col("boolean", "BOOLEAN")
+        # These look like they should be equivalent, but the default is actually ``BIT(1)`` for MySQL.
+        coldata.col("boolean", "BOOLEAN")
 
-            with self.assertRaises(ValidationError):
-                coldata.col("unicode", "NVARCHAR", length=32)
+        with self.assertRaises(ValidationError):
+            coldata.col("unicode", "NVARCHAR", length=32)
 
-            with self.assertRaises(ValidationError):
-                coldata.col("timestamp", "TIMESTAMP")
+        with self.assertRaises(ValidationError):
+            coldata.col("timestamp", "TIMESTAMP")
 
-            # DM-42257: Felis does not handle unbounded text types properly.
-            # coldata.col("text", "TEXT", length=32)
+        # DM-42257: Felis does not handle unbounded text types properly.
+        # coldata.col("text", "TEXT", length=32)
 
-            with self.assertRaises(ValidationError):
-                coldata.col("binary", "LONGBLOB", length=1024)
+        with self.assertRaises(ValidationError):
+            coldata.col("binary", "LONGBLOB", length=1024)
 
-            with self.assertRaises(ValidationError):
-                # Same type and length
-                coldata.col("string", "VARCHAR(128)", length=128)
+        with self.assertRaises(ValidationError):
+            # Same type and length
+            coldata.col("string", "VARCHAR(128)", length=128)
 
-            # Different types, which is okay
-            coldata.col("double", "FLOAT")
+        # Different types, which is okay
+        coldata.col("double", "FLOAT")
 
-            # Same base type with different lengths, which is okay
-            coldata.col("string", "VARCHAR(128)", length=32)
+        # Same base type with different lengths, which is okay
+        coldata.col("string", "VARCHAR(128)", length=32)
 
-            # Different string types, which is okay
-            coldata.col("string", "CHAR", length=32)
-            coldata.col("unicode", "CHAR", length=32)
-
-        finally:
-            Schema.Config.check_redundant_datatypes = False
+        # Different string types, which is okay
+        coldata.col("string", "CHAR", length=32)
+        coldata.col("unicode", "CHAR", length=32)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Revert #54 which itself reverted #50 

Fix the dependence on global state by using [Pydantic context](https://docs.pydantic.dev/latest/concepts/validators/#validation-context) instead.

Summary of changes:

- Use Pydantic `context` object instead of globals for validation flags and remove all class variables from `Schema` controlling validation behavior.
- Turn `validate_assignment` off for now as it can lead to undesirable validation behavior.
- Change the validation of descriptions to an "after" rather than "before" validator and use `ValidationInfo` instead of a global flag.
- Change the `DataType` enum in `datamodel` to `StrEnum` so it can be used interchangeably where a string value is required.
- Add `string_to_typeengine` utility for converting datatype strings to SQLAlchemy types.
- Change validation function for checking redundant datatypes to "after" and use `ValidationInfo`.
- Build the schema's ID map in `model_post_init()` rather than a validator.
- Remove non-standard mapping of `DOUBLE` to `FLOAT` for MySQL and just use SQLAlchemy's default type mapping instead.
- Add new test module `test_datatypes` which checks the validation of when `datatype` and a `mysql:datatype` are both provided in a column description.