### PR TITLE
DM-43751: Change default type mapping for boolean to BOOLEAN for MySQL

### DIFF
--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -47,7 +47,7 @@ def compile_tinyint(type_: Any, compiler: Any, **kw: Any) -> str:
 
 _TypeMap = Mapping[str, types.TypeEngine | type[types.TypeEngine]]
 
-boolean_map: _TypeMap = {MYSQL: mysql.BIT(1), ORACLE: oracle.NUMBER(1), POSTGRES: postgresql.BOOLEAN()}
+boolean_map: _TypeMap = {MYSQL: mysql.BOOLEAN, ORACLE: oracle.NUMBER(1), POSTGRES: postgresql.BOOLEAN()}
 
 byte_map: _TypeMap = {
     MYSQL: mysql.TINYINT(),

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -62,9 +62,6 @@ class RedundantDatatypesTest(unittest.TestCase):
             coldata.col("int", "INTEGER")
 
         with self.assertRaises(ValidationError):
-            coldata.col("boolean", "BIT(1)")
-
-        with self.assertRaises(ValidationError):
             coldata.col("float", "FLOAT")
 
         with self.assertRaises(ValidationError):
@@ -82,9 +79,8 @@ class RedundantDatatypesTest(unittest.TestCase):
         with self.assertRaises(ValidationError):
             coldata.col("long", "BIGINT")
 
-        # These look like they should be equivalent, but the default is
-        # actually ``BIT(1)`` for MySQL.
-        coldata.col("boolean", "BOOLEAN")
+        with self.assertRaises(ValidationError):
+            coldata.col("boolean", "BOOLEAN")
 
         with self.assertRaises(ValidationError):
             coldata.col("unicode", "NVARCHAR", length=32)
@@ -101,6 +97,9 @@ class RedundantDatatypesTest(unittest.TestCase):
         with self.assertRaises(ValidationError):
             # Same type and length
             coldata.col("string", "VARCHAR(128)", length=128)
+
+        # Check the old type mapping for MySQL, which is now okay
+        coldata.col("boolean", "BIT(1)")
 
         # Different types, which is okay
         coldata.col("double", "FLOAT")


### PR DESCRIPTION
Felis currently maps the boolean type to `BIT(1)` in MySQL, but it would be better to use its standard `BOOLEAN` datatype instead. This would make the usage of `mysql:datatype: BOOLEAN` in some of the columns a redundant override that should be removed, which is intended.

- [x] @gpdf requests to check with @iagaponenko that the live Qserv columns and ingest configuration use the `BOOLEAN` type