### PR TITLE
Improve the log statements and error messages in the redundant type checking validation

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -287,22 +287,26 @@ class Column(BaseObject):
                 db_datatype_obj = string_to_typeengine(datatype_string, dialect, length)
                 if datatype_obj.compile(dialect) == db_datatype_obj.compile(dialect):
                     raise ValueError(
-                        "'{}: {}' is the same as 'datatype: {}' in column '{}'".format(
-                            db_annotation, datatype_string, col.datatype, col.id
+                        "'{}: {}' is a redundant override of 'datatype: {}' in column '{}'{}".format(
+                            db_annotation,
+                            datatype_string,
+                            col.datatype,
+                            col.id,
+                            "" if length is None else f" with length {length}",
                         )
                     )
                 else:
                     logger.debug(
-                        "Valid type override of 'datatype: {}' with '{}: {}' in column '{}'".format(
-                            col.datatype, db_annotation, datatype_string, col.id
+                        "Type override of 'datatype: {}' with '{}: {}' in column '{}' "
+                        "compiled to '{}' and '{}'".format(
+                            col.datatype,
+                            db_annotation,
+                            datatype_string,
+                            col.id,
+                            datatype_obj.compile(dialect),
+                            db_datatype_obj.compile(dialect),
                         )
                     )
-                    logger.debug(
-                        "Compiled datatype '{}' with {} compiled override '{}'".format(
-                            datatype_obj.compile(dialect), dialect_name, db_datatype_obj.compile(dialect)
-                        )
-                    )
-
         return col
 
 


### PR DESCRIPTION
Overrides that are not considered validation errors will print a `DEBUG` level message like this on one line instead of two now:

```
DEBUG:felis.datamodel:Type override of 'datatype: timestamp' with 'mysql_datatype: DATETIME' in column '#DiaObject.lastNonForcedSource' compiled to 'TIMESTAMP' and 'DATETIME'
```

Those that are redundant and considered validation errors will show like this, with the column's length in the error message (if applicable):

```
Value error, 'mysql_datatype: VARCHAR(64)' is a redundant override of 'datatype: string' in column '#DiaObject.nearbyLowzGal' with length 64
```

Text was changed so that "redundant override" can be used when grep'ing through the logs for errors.