### PR TITLE
DM-43753: Make columns nullable by default in the data model

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -181,13 +181,8 @@ class Column(BaseObject):
     length: int | None = None
     """The length of the column."""
 
-    nullable: bool | None = None
-    """Whether the column can be ``NULL``.
-
-    If `None`, this value was not set explicitly in the YAML data. In this
-    case, it will be set to `False` for columns with numeric types and `True`
-    otherwise.
-    """
+    nullable: bool = True
+    """Whether the column can be ``NULL``."""
 
     value: Any = None
     """The default value of the column."""

--- a/python/felis/metadata.py
+++ b/python/felis/metadata.py
@@ -34,7 +34,6 @@ from sqlalchemy import (
     ForeignKeyConstraint,
     Index,
     MetaData,
-    Numeric,
     PrimaryKeyConstraint,
     ResultProxy,
     Table,
@@ -265,17 +264,12 @@ class MetaDataBuilder:
         id = column_obj.id
         description = column_obj.description
         default = column_obj.value
+        nullable = column_obj.nullable
 
-        # Handle variant overrides for the column (e.g., "mysql:datatype").
+        # Get datatype, handling variant overrides such as "mysql:datatype".
         datatype = get_datatype_with_variants(column_obj)
 
-        # Set default value of nullable based on column type and then whether
-        # it was explicitly provided in the schema data.
-        nullable = column_obj.nullable
-        if nullable is None:
-            nullable = False if isinstance(datatype, Numeric) else True
-
-        # Set autoincrement depending on if it was provided explicitly.
+        # Set autoincrement, depending on if it was provided explicitly.
         autoincrement: Literal["auto"] | bool = (
             column_obj.autoincrement if column_obj.autoincrement is not None else "auto"
         )


### PR DESCRIPTION
The previous approach, which made numeric columns non-nullable while other types were nullable, was not logical considering that SQL columns in DDL are always nullable by default.