### PR TITLE
DM-43995: Handle default column values properly when defining columns in metadata

### DIFF
--- a/tests/data/sales.yaml
+++ b/tests/data/sales.yaml
@@ -22,6 +22,12 @@ tables:
         datatype: string
         description: Customer address
         length: 100
+      - name: note
+        "@id": "#customers.note"
+        description: Customer note
+        datatype: string
+        length: 256
+        value: ""
     indexes:
       - name: idx_name
         "@id": "#customers_idx_name"
@@ -52,6 +58,13 @@ tables:
         "@id": "#orders.order_date"
         datatype: timestamp
         description: Order date
+        value: CURRENT_TIMESTAMP
+      - name: note
+        "@id": "#orders.note"
+        description: Order note
+        datatype: string
+        length: 256
+        value:
     constraints:
       - name: fk_customer_id
         "@id": "#orders_fk_customer_id"
@@ -82,6 +95,13 @@ tables:
         "@id": "#items.quantity"
         datatype: int
         description: Quantity ordered
+        value: 1
+      - name: note
+        "@id": "#items.note"
+        description: Item note
+        datatype: string
+        length: 256
+        value: "No note"
     constraints:
       - name: non_negative_quantity
         "@id": "#items_non_negative_quantity"

--- a/tests/data/test.yml
+++ b/tests/data/test.yml
@@ -249,7 +249,7 @@ tables:
         "@id": "#sdqa_Threshold.createdDate"
         datatype: timestamp
         description: Database timestamp when the record is inserted.
-        # value: CURRENT_TIMESTAMP  ## DM-43312: This causes an error due to quoting.
+        value: CURRENT_TIMESTAMP
         mysql:datatype: TIMESTAMP
     primaryKey: "#sdqa_Threshold.sdqa_thresholdId"
     indexes:


### PR DESCRIPTION
The `server_default` on a SQLAlchemy column always needs to be a string. In the YAML, it might be a numeric or other type which will cause an error if used directly. This change makes sure that these values are always compiled to a SQL string instead.

Test data was updated, in one case adding back a default that had been causing errors previously, and in another adding several new defaults to the `sales.yml` schema used for testing the metadata interface.

This change also fixes [DM-43312](https://rubinobs.atlassian.net/browse/DM-43312), as `metadata` will handle SQL functions like `CURRENT_TIMESTAMP` properly now.

[DM-43312]: https://rubinobs.atlassian.net/browse/DM-43312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ