### PR TITLE
DM-43998: Properly validate default values and fix their handling in SQL metadata

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -276,18 +276,17 @@ class Column(BaseObject):
 
         return values
 
-    @model_validator(mode="after")  # type: ignore[arg-type]
-    @classmethod
-    def validate_datatypes(cls, col: Column, info: ValidationInfo) -> Column:
+    @model_validator(mode="after")
+    def check_datatypes(self, info: ValidationInfo) -> Column:
         """Check for redundant datatypes on columns."""
         context = info.context
         if not context or not context.get("check_redundant_datatypes", False):
-            return col
-        if all(getattr(col, f"{dialect}:datatype", None) is not None for dialect in _DIALECTS.keys()):
-            return col
+            return self
+        if all(getattr(self, f"{dialect}:datatype", None) is not None for dialect in _DIALECTS.keys()):
+            return self
 
-        datatype = col.datatype
-        length: int | None = col.length or None
+        datatype = self.datatype
+        length: int | None = self.length or None
 
         datatype_func = get_type_func(datatype)
         felis_type = FelisType.felis_type(datatype)
@@ -295,32 +294,32 @@ class Column(BaseObject):
             if length is not None:
                 datatype_obj = datatype_func(length)
             else:
-                raise ValueError(f"Length must be provided for sized type '{datatype}' in column '{col.id}'")
+                raise ValueError(f"Length must be provided for sized type '{datatype}' in column '{self.id}'")
         else:
             datatype_obj = datatype_func()
 
         for dialect_name, dialect in _DIALECTS.items():
             db_annotation = f"{dialect_name}_datatype"
-            if datatype_string := col.model_dump().get(db_annotation):
+            if datatype_string := self.model_dump().get(db_annotation):
                 db_datatype_obj = string_to_typeengine(datatype_string, dialect, length)
                 if datatype_obj.compile(dialect) == db_datatype_obj.compile(dialect):
                     raise ValueError(
                         "'{}: {}' is a redundant override of 'datatype: {}' in column '{}'{}".format(
                             db_annotation,
                             datatype_string,
-                            col.datatype,
-                            col.id,
+                            self.datatype,
+                            self.id,
                             "" if length is None else f" with length {length}",
                         )
                     )
                 else:
                     logger.debug(
-                        f"Type override of 'datatype: {col.datatype}' "
-                        f"with '{db_annotation}: {datatype_string}' in column '{col.id}' "
+                        f"Type override of 'datatype: {self.datatype}' "
+                        f"with '{db_annotation}: {datatype_string}' in column '{self.id}' "
                         f"compiled to '{datatype_obj.compile(dialect)}' and "
                         f"'{db_datatype_obj.compile(dialect)}'"
                     )
-        return col
+        return self
 
 
 class Constraint(BaseObject):

--- a/python/felis/metadata.py
+++ b/python/felis/metadata.py
@@ -484,7 +484,7 @@ class DatabaseContext:
                 self.connection.execute(text(f"DROP DATABASE IF EXISTS {schema_name}"))
             elif db_type == "postgresql":
                 logger.info(f"Dropping PostgreSQL schema if exists: {schema_name}")
-                self.connection.execute(sqa_schema.DropSchema(schema_name, if_exists=True))
+                self.connection.execute(sqa_schema.DropSchema(schema_name, if_exists=True, cascade=True))
             else:
                 raise ValueError(f"Unsupported database type: {db_type}")
         except SQLAlchemyError as e:

--- a/python/felis/metadata.py
+++ b/python/felis/metadata.py
@@ -37,6 +37,7 @@ from sqlalchemy import (
     PrimaryKeyConstraint,
     ResultProxy,
     Table,
+    TextClause,
     UniqueConstraint,
     create_mock_engine,
     make_url,
@@ -132,6 +133,9 @@ def get_datatype_with_variants(column_obj: datamodel.Column) -> TypeEngine:
     else:
         datatype = datatype_fun(**variant_dict)
     return datatype
+
+
+_VALID_SERVER_DEFAULTS = ("CURRENT_TIMESTAMP", "NOW()", "LOCALTIMESTAMP", "NULL")
 
 
 class MetaDataBuilder:
@@ -263,7 +267,7 @@ class MetaDataBuilder:
         name = column_obj.name
         id = column_obj.id
         description = column_obj.description
-        default = column_obj.value
+        value = column_obj.value
         nullable = column_obj.nullable
 
         # Get datatype, handling variant overrides such as "mysql:datatype".
@@ -274,13 +278,24 @@ class MetaDataBuilder:
             column_obj.autoincrement if column_obj.autoincrement is not None else "auto"
         )
 
+        server_default: str | TextClause | None = None
+        if value is not None:
+            server_default = str(value)
+            if server_default in _VALID_SERVER_DEFAULTS or not isinstance(value, str):
+                # If the server default is a valid keyword or not a string,
+                # use it as is.
+                server_default = text(server_default)
+
+        if server_default is not None:
+            logger.debug(f"Column '{id}' has default value: {server_default}")
+
         column: Column = Column(
             name,
             datatype,
             comment=description,
             autoincrement=autoincrement,
             nullable=nullable,
-            server_default=default,
+            server_default=server_default,
         )
 
         self._objects[id] = column

--- a/tests/data/sales.yaml
+++ b/tests/data/sales.yaml
@@ -52,6 +52,12 @@ tables:
         "@id": "#orders.order_date"
         datatype: timestamp
         description: Order date
+        value: CURRENT_TIMESTAMP
+      - name: note
+        "@id": "#orders.note"
+        description: Order note
+        datatype: string
+        length: 256
     constraints:
       - name: fk_customer_id
         "@id": "#orders_fk_customer_id"
@@ -82,6 +88,13 @@ tables:
         "@id": "#items.quantity"
         datatype: int
         description: Quantity ordered
+        value: 1
+      - name: note
+        "@id": "#items.note"
+        description: Item note
+        datatype: string
+        length: 256
+        value: "No note"
     constraints:
       - name: non_negative_quantity
         "@id": "#items_non_negative_quantity"

--- a/tests/data/test.yml
+++ b/tests/data/test.yml
@@ -249,7 +249,7 @@ tables:
         "@id": "#sdqa_Threshold.createdDate"
         datatype: timestamp
         description: Database timestamp when the record is inserted.
-        # value: CURRENT_TIMESTAMP  ## DM-43312: This causes an error due to quoting.
+        value: CURRENT_TIMESTAMP
         mysql:datatype: TIMESTAMP
     primaryKey: "#sdqa_Threshold.sdqa_thresholdId"
     indexes:


### PR DESCRIPTION
This fixes the handling of the `value` field when creating SQLAlchemy metadata. String literals are quoted, except when the value is a SQL function such as `CURRENT_TIMESTAMP`. In this case, quotes are omitted.

A thorough validation function was also added to the data model for checking `value` if it was provided. This will make sure that the provided value is valid given the datatype of the column.

Finally, a new test method was added to check the validation function for all of the Felis datatypes, both when valid and invalid data is provided.