### PR TITLE
Update ruff config and fix style errors

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,3 +9,8 @@ on:
 jobs:
   call-workflow:
     uses: lsst/rubin_workflows/.github/workflows/lint.yaml@main
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chartboost/ruff-action@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.289
+    rev: v0.4.1
     hooks:
       - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
         args:
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
+    rev: 24.4.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -17,7 +17,7 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.11
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,12 +114,27 @@ line_length = 110
 write_to = "python/felis/version.py"
 
 [tool.ruff]
+line-length = 110
+target-version = "py311"
 exclude = [
     "__init__.py",
     "lex.py",
     "yacc.py",
 ]
+
+[tool.ruff.lint]
 ignore = [
+    "D100",
+    "D102",
+    "D104",
+    "D105",
+    "D107",
+    "D200",
+    "D203",
+    "D205",
+    "D213",
+    "D400",
+    "D413",
     "N802",
     "N803",
     "N806",
@@ -127,26 +142,16 @@ ignore = [
     "N815",
     "N816",
     "N999",
-    "D107",
-    "D105",
-    "D102",
-    "D104",
-    "D100",
-    "D200",
-    "D205",
-    "D203",
-    "D213",
-    "D400",
+    "UP007",  # Allow UNION in type annotation
 ]
-line-length = 110
 select = [
     "E",  # pycodestyle
     "F",  # pycodestyle
     "N",  # pep8-naming
     "W",  # pycodestyle
     "D",  # pydocstyle
+    "UP",  # pyupgrade
 ]
-target-version = "py311"
 
 [tool.pydeps]
 max_bacon = 2

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -294,15 +294,10 @@ class Column(BaseObject):
                     )
                 else:
                     logger.debug(
-                        "Type override of 'datatype: {}' with '{}: {}' in column '{}' "
-                        "compiled to '{}' and '{}'".format(
-                            col.datatype,
-                            db_annotation,
-                            datatype_string,
-                            col.id,
-                            datatype_obj.compile(dialect),
-                            db_datatype_obj.compile(dialect),
-                        )
+                        f"Type override of 'datatype: {col.datatype}' "
+                        f"with '{db_annotation}: {datatype_string}' in column '{col.id}' "
+                        f"compiled to '{datatype_obj.compile(dialect)}' and "
+                        f"'{db_datatype_obj.compile(dialect)}'"
                     )
         return col
 
@@ -459,7 +454,7 @@ class SchemaIdVisitor:
 
     def __init__(self) -> None:
         """Create a new SchemaVisitor."""
-        self.schema: "Schema" | None = None
+        self.schema: Schema | None = None
         self.duplicates: set[str] = set()
 
     def add(self, obj: BaseObject) -> None:
@@ -472,7 +467,7 @@ class SchemaIdVisitor:
                 else:
                     self.schema.id_map[obj_id] = obj
 
-    def visit_schema(self, schema: "Schema") -> None:
+    def visit_schema(self, schema: Schema) -> None:
         """Visit the schema object that was added during initialization.
 
         This will set an internal variable pointing to the schema object.

--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -20,8 +20,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import builtins
-from collections.abc import Mapping
-from typing import Any, Callable
+from collections.abc import Callable, Mapping
+from typing import Any
 
 from sqlalchemy import SmallInteger, types
 from sqlalchemy.dialects import mysql, oracle, postgresql

--- a/python/felis/tap.py
+++ b/python/felis/tap.py
@@ -186,7 +186,7 @@ class TapLoadingVisitor:
         schema.description = schema_obj.description
         schema.utype = schema_obj.votable_utype
         schema.schema_index = self.tap_schema_index
-        logger.debug("Set TAP_SCHEMA index: {}".format(self.tap_schema_index))
+        logger.debug(f"Set TAP_SCHEMA index: {self.tap_schema_index}")
 
         if self.engine is not None:
             session: Session = sessionmaker(self.engine)()

--- a/python/felis/validation.py
+++ b/python/felis/validation.py
@@ -60,7 +60,7 @@ class RspTable(Table):
 
     @model_validator(mode="after")  # type: ignore[arg-type]
     @classmethod
-    def check_tap_principal(cls: Any, tbl: "RspTable") -> "RspTable":
+    def check_tap_principal(cls: Any, tbl: RspTable) -> RspTable:
         """Check that at least one column is flagged as 'principal' for
         TAP purposes.
         """


### PR DESCRIPTION
Update the ruff configuration for Python code linting and fix reported errors in the codebase.

Changes included:

- Updated all pre-commit repo versions using `pre-commit autoupdate`
- Updated `lint.yaml` workflow to run `ruff-action`
- Replaced ruff config in `pyproject.toml` with daf_butler's
- Added a few additional items to ruff's ignore list (D203, D213, D413)
- Sorted the ruff ignore list alphabetically so it was easier to manage
- Fixed all style errors reported by `ruff` based on the new configuration

Jenkins CI has passed on this branch:

https://rubin-ci.slac.stanford.edu/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/1243/pipeline