### PR TITLE
DM-43371: Add validation of length for sized datatypes

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -291,6 +291,11 @@ class Column(BaseObject):
                 f"Length must be provided for type '{datatype}'"
                 + (f" in column '{values['@id']}'" if "@id" in values else "")
             )
+        elif not felis_type.is_sized and length is not None:
+            logger.warning(
+                f"The datatype '{datatype}' does not support a specified length"
+                + (f" in column '{values['@id']}'" if "@id" in values else "")
+            )
         return values
 
     @model_validator(mode="after")

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -73,13 +73,13 @@ class ColumnTestCase(unittest.TestCase):
 
         # Setting name, id, and datatype should not throw an exception and
         # should load data correctly.
-        col = Column(name="testColumn", id="#test_id", datatype="string")
+        col = Column(name="testColumn", id="#test_id", datatype="string", length=256)
         self.assertEqual(col.name, "testColumn", "name should be 'testColumn'")
         self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
         self.assertEqual(col.datatype, DataType.string, "datatype should be 'DataType.string'")
 
         # Creating from data dictionary should work and load data correctly.
-        data = {"name": "testColumn", "id": "#test_id", "datatype": "string"}
+        data = {"name": "testColumn", "id": "#test_id", "datatype": "string", "length": 256}
         col = Column(**data)
         self.assertEqual(col.name, "testColumn", "name should be 'testColumn'")
         self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
@@ -422,7 +422,7 @@ class TableTestCase(unittest.TestCase):
         with self.assertRaises(ValidationError):
             Index(name="testTable", id="#test_id")
 
-        testCol = Column(name="testColumn", id="#test_id", datatype="string")
+        testCol = Column(name="testColumn", id="#test_id", datatype="string", length=256)
 
         # Setting name, id, and columns should not throw an exception and
         # should load data correctly.
@@ -453,7 +453,7 @@ class SchemaTestCase(unittest.TestCase):
         with self.assertRaises(ValidationError):
             Schema(name="testSchema", id="#test_id")
 
-        test_col = Column(name="testColumn", id="#test_col_id", datatype="string")
+        test_col = Column(name="testColumn", id="#test_col_id", datatype="string", length=256)
         test_tbl = Table(name="testTable", id="#test_tbl_id", columns=[test_col])
 
         # Setting name, id, and columns should not throw an exception and
@@ -491,7 +491,7 @@ class SchemaTestCase(unittest.TestCase):
 
     def test_schema_object_ids(self) -> None:
         """Test that the id_map is properly populated."""
-        test_col = Column(name="testColumn", id="#test_col_id", datatype="string")
+        test_col = Column(name="testColumn", id="#test_col_id", datatype="string", length=256)
         test_tbl = Table(name="testTable", id="#test_table_id", columns=[test_col])
         sch = Schema(name="testSchema", id="#test_schema_id", tables=[test_tbl])
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -58,6 +58,7 @@ class RSPSchemaTestCase(unittest.TestCase):
                 "@id": "#test_col_id",
                 "datatype": "string",
                 "description": "test column",
+                "length": 256,
                 "tap:principal": 1,
             }
         )
@@ -191,6 +192,7 @@ class RSPSchemaTestCase(unittest.TestCase):
                                     "datatype": "string",
                                     "description": "test column",
                                     "tap:principal": 1,
+                                    "length": 256,
                                 }
                             )
                         ],
@@ -210,6 +212,7 @@ class RSPSchemaTestCase(unittest.TestCase):
                                     "datatype": "string",
                                     "description": "test column",
                                     "tap:principal": 1,
+                                    "length": 256,
                                 }
                             )
                         ],


### PR DESCRIPTION
Add a standalone validation function that checks if a sized type has a length and raises an error if not.

Add a requirement that the length field in the data model is greater than zero.

Add lengths to some string columns in the tests, as length is always required now for `Column` objects.

This and the related [sdm_schemas PR](https://github.com/lsst/sdm_schemas/pull/212) have been [checked in CI](https://rubin-ci.slac.stanford.edu/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/1311/pipeline).