### PR TITLE
Allow variant datatype overrides to be ignored

### DIFF
--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -98,16 +98,16 @@ def create(
     schema = Schema.model_validate(yaml_data)
     url_obj = make_url(engine_url)
     if schema_name:
-        logger.info(f"Overriding schema name with: {schema_name}")
+        logger.debug(f"Overriding schema name with: {schema_name}")
         schema.name = schema_name
     elif url_obj.drivername == "sqlite":
-        logger.info("Overriding schema name for sqlite with: main")
+        logger.debug("Overriding schema name for sqlite with: main")
         schema.name = "main"
     if not url_obj.host and not url_obj.drivername == "sqlite":
         dry_run = True
-        logger.info("Forcing dry run for non-sqlite engine URL with no host")
+        logger.debug("Forcing dry run for non-sqlite engine URL with no host")
     if not include_datatype_variants:
-        logger.info("Ignoring datatype variants")
+        logger.debug("Ignoring datatype variants")
 
     builder = MetaDataBuilder(schema, include_datatype_variants=include_datatype_variants)
     builder.build()
@@ -119,10 +119,10 @@ def create(
         engine = create_engine(engine_url, echo=echo)
     else:
         if dry_run:
-            logger.info("Dry run will be executed")
+            logger.debug("Dry run will be executed")
         engine = DatabaseContext.create_mock_engine(url_obj, output_file)
         if output_file:
-            logger.info("Writing SQL output to: " + output_file.name)
+            logger.debug("Writing SQL output to: " + output_file.name)
 
     context = DatabaseContext(metadata, engine)
 

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -76,6 +76,9 @@ def cli(log_level: str, log_file: str | None) -> None:
 @click.option("--echo", is_flag=True, help="Echo database commands as they are executed")
 @click.option("--dry-run", is_flag=True, help="Dry run only to print out commands instead of executing")
 @click.option(
+    "--include-datatype-variants", is_flag=True, help="Ignore datatype variants in the schema", default=True
+)
+@click.option(
     "--output-file", "-o", type=click.File(mode="w"), help="Write SQL commands to a file instead of executing"
 )
 @click.argument("file", type=click.File())
@@ -86,6 +89,7 @@ def create(
     drop_if_exists: bool,
     echo: bool,
     dry_run: bool,
+    include_datatype_variants: bool,
     output_file: IO[str] | None,
     file: IO,
 ) -> None:
@@ -102,8 +106,10 @@ def create(
     if not url_obj.host and not url_obj.drivername == "sqlite":
         dry_run = True
         logger.info("Forcing dry run for non-sqlite engine URL with no host")
+    if not include_datatype_variants:
+        logger.info("Ignoring datatype variants")
 
-    builder = MetaDataBuilder(schema)
+    builder = MetaDataBuilder(schema, include_datatype_variants=include_datatype_variants)
     builder.build()
     metadata = builder.metadata
     logger.debug(f"Created metadata with schema name: {metadata.schema}")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -36,7 +36,7 @@ from sqlalchemy import (
 
 from felis import datamodel as dm
 from felis.datamodel import Schema
-from felis.metadata import DatabaseContext, MetaDataBuilder, get_datatype_with_variants
+from felis.metadata import DatabaseContext, MetaDataBuilder, get_datatype
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 TEST_YAML = os.path.join(TESTDIR, "data", "sales.yaml")
@@ -155,7 +155,7 @@ class MetaDataTestCase(unittest.TestCase):
             self.assertEqual(len(table.columns), len(md_table.columns))
             for column in table.columns:
                 md_table_column = md_table.columns[column.name]
-                datatype = get_datatype_with_variants(column)
+                datatype = get_datatype(column)
                 self.assertEqual(type(datatype), type(md_table_column.type))
                 if column.nullable is not None:
                     self.assertEqual(column.nullable, md_table_column.nullable)


### PR DESCRIPTION
This allows the variant datatype overrides defined by the type system in Felis to be turned off when creating SQLAlchemy MetaData.