### PR TITLE
DM-44059: Add better support for datetime and timestamp

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -125,11 +125,13 @@ class DataType(StrEnum):
     text = auto()
     binary = auto()
     timestamp = auto()
+    datetime = auto()
 
 
 _DIALECTS = {
     "mysql": create_mock_engine("mysql://", executor=None).dialect,
     "postgresql": create_mock_engine("postgresql://", executor=None).dialect,
+    "sqlite": create_mock_engine("sqlite://", executor=None).dialect,
 }
 """Dictionary of dialect names to SQLAlchemy dialects."""
 
@@ -180,6 +182,13 @@ class Column(BaseObject):
 
     length: int | None = Field(None, gt=0)
     """The length of the column."""
+
+    precision: int | None = Field(None, ge=0)
+    """The numerical precision of the column, the exact meaning of which may
+    depend on the datatype."""
+
+    timezone: bool = False
+    """Whether a timestamp or datetime has a timezone."""
 
     nullable: bool = True
     """Whether the column can be ``NULL``."""

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -187,9 +187,6 @@ class Column(BaseObject):
     """The numerical precision of the column, the exact meaning of which may
     depend on the datatype."""
 
-    timezone: bool = False
-    """Whether a timestamp or datetime has a timezone."""
-
     nullable: bool = True
     """Whether the column can be ``NULL``."""
 

--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -115,6 +115,16 @@ binary_map: _TypeMap = {
     POSTGRES: postgresql.BYTEA,
 }
 
+timestamp_map: _TypeMap = {
+    MYSQL: mysql.TIMESTAMP,
+    POSTGRES: postgresql.TIMESTAMP,
+}
+
+datetime_map: _TypeMap = {
+    MYSQL: mysql.DATETIME,
+    POSTGRES: postgresql.TIMESTAMP,
+}
+
 
 def boolean(**kwargs: Any) -> types.TypeEngine:
     """Return SQLAlchemy type for boolean."""
@@ -178,7 +188,12 @@ def binary(length: builtins.int, **kwargs: Any) -> types.TypeEngine:
 
 def timestamp(**kwargs: Any) -> types.TypeEngine:
     """Return SQLAlchemy type for timestamp."""
-    return types.TIMESTAMP()
+    return _vary(types.TIMESTAMP(), timestamp_map, kwargs)
+
+
+def datetime(**kwargs: Any) -> types.TypeEngine:
+    """Return SQLAlchemy type for datetime."""
+    return _vary(types.DATETIME(), datetime_map, kwargs)
 
 
 def get_type_func(type_name: str) -> Callable:

--- a/python/felis/metadata.py
+++ b/python/felis/metadata.py
@@ -131,13 +131,13 @@ def _handle_timestamp_variants(column_obj: datamodel.Column, variant_dict: dict[
         # Determine the MySQL type based on the datatype
         mysql_type: dialects.mysql.TIMESTAMP | dialects.mysql.DATETIME
         if column_obj.datatype == "timestamp":
-            mysql_type = dialects.mysql.TIMESTAMP(timezone=column_obj.timezone, fsp=column_obj.precision)
+            mysql_type = dialects.mysql.TIMESTAMP(fsp=column_obj.precision)
         else:
-            mysql_type = dialects.mysql.DATETIME(timezone=column_obj.timezone, fsp=column_obj.precision)
+            mysql_type = dialects.mysql.DATETIME(fsp=column_obj.precision)
 
         # Create the PostgreSQL type with the appropriate parameters
         postgresql_type = dialects.postgresql.TIMESTAMP(
-            timezone=column_obj.timezone, precision=column_obj.precision
+            precision=column_obj.precision
         )
 
         # Set the types in the variant dictionary if they're not already set

--- a/python/felis/types.py
+++ b/python/felis/types.py
@@ -135,3 +135,7 @@ class Binary(FelisType, felis_name="binary", votable_name="unsignedByte", is_siz
 
 class Timestamp(FelisType, felis_name="timestamp", votable_name="char", is_timestamp=True):
     """Felis definition of timestamp type."""
+
+
+class Datetime(FelisType, felis_name="datetime", votable_name="char", is_timestamp=True):
+    """Felis definition of datetime type."""

--- a/tests/data/sales.yaml
+++ b/tests/data/sales.yaml
@@ -22,6 +22,10 @@ tables:
         datatype: string
         description: Customer address
         length: 100
+      - name: joined
+        "@id": "#customers.joined"
+        datatype: datetime
+        description: Date customer joined
     indexes:
       - name: idx_name
         "@id": "#customers_idx_name"
@@ -50,8 +54,17 @@ tables:
         description: Customer identifier
       - name: order_date
         "@id": "#orders.order_date"
-        datatype: timestamp
+        datatype: datetime
+        precision: 2
+        timezone: true
         description: Order date
+        value: CURRENT_TIMESTAMP
+      - name: updated
+        "@id": "#orders.updated"
+        datatype: timestamp
+        precision: 4
+        timezone: true
+        description: Date last updated
         value: CURRENT_TIMESTAMP
       - name: note
         "@id": "#orders.note"
@@ -89,6 +102,11 @@ tables:
         datatype: int
         description: Quantity ordered
         value: 1
+      - name: added
+        "@id": "#items.added"
+        datatype: timestamp
+        description: Date item added to order
+        value: CURRENT_TIMESTAMP
       - name: note
         "@id": "#items.note"
         description: Item note

--- a/tests/data/sales.yaml
+++ b/tests/data/sales.yaml
@@ -56,14 +56,12 @@ tables:
         "@id": "#orders.order_date"
         datatype: datetime
         precision: 2
-        timezone: true
         description: Order date
         value: CURRENT_TIMESTAMP
       - name: updated
         "@id": "#orders.updated"
         datatype: timestamp
         precision: 4
-        timezone: true
         description: Date last updated
         value: CURRENT_TIMESTAMP
       - name: note

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -21,10 +21,9 @@
 
 import unittest
 
-from pydantic import ValidationError
-
 from felis.datamodel import _DIALECTS, Column
 from felis.metadata import get_datatype_with_variants
+from pydantic import ValidationError
 
 
 class ColumnGenerator:
@@ -60,43 +59,35 @@ class TimestampDatatypesTest(unittest.TestCase):
             dialect = _DIALECTS[db_name] if db_name else None
             for datatype in ["timestamp", "datetime"]:
                 for precision in [None, 6]:
-                    for timezone in [True, False]:
-                        print(f"{db_name}, {datatype}, precision={precision}, tz={timezone}")
-                        col = colgen.col(datatype)
-                        col.precision = precision
-                        col.timezone = timezone
-                        sql_datatype = get_datatype_with_variants(col)
-                        sql = sql_datatype.compile(dialect)
-                        print(sql)
+                    print(f"{db_name}, {datatype}, precision={precision}")
+                    col = colgen.col(datatype)
+                    col.precision = precision
+                    sql_datatype = get_datatype_with_variants(col)
+                    sql = sql_datatype.compile(dialect)
+                    print(sql)
 
-                        if db_name == "mysql":
-                            if datatype == "timestamp":
-                                if precision is None:
-                                    self.assertEqual(sql, "TIMESTAMP")
-                                else:
-                                    self.assertEqual(sql, f"TIMESTAMP({precision})")
-                            elif datatype == "datetime":
-                                if precision is None:
-                                    self.assertEqual(sql, "DATETIME")
-                                else:
-                                    self.assertEqual(sql, f"DATETIME({precision})")
-                        elif db_name == "postgresql":
-                            if timezone:
-                                if precision is None:
-                                    self.assertEqual(sql, "TIMESTAMP WITH TIME ZONE")
-                                else:
-                                    self.assertEqual(sql, f"TIMESTAMP({precision}) WITH TIME ZONE")
-                            else:
-                                if precision is None:
-                                    self.assertEqual(sql, "TIMESTAMP WITHOUT TIME ZONE")
-                                else:
-                                    self.assertEqual(sql, f"TIMESTAMP({precision}) WITHOUT TIME ZONE")
-                        elif db_name in [None, "sqlite"]:
-                            if datatype == "timestamp":
+                    if db_name == "mysql":
+                        if datatype == "timestamp":
+                            if precision is None:
                                 self.assertEqual(sql, "TIMESTAMP")
-                            elif datatype == "datetime":
+                            else:
+                                self.assertEqual(sql, f"TIMESTAMP({precision})")
+                        elif datatype == "datetime":
+                            if precision is None:
                                 self.assertEqual(sql, "DATETIME")
-                        print("")
+                            else:
+                                self.assertEqual(sql, f"DATETIME({precision})")
+                    elif db_name == "postgresql":
+                        if precision is None:
+                            self.assertEqual(sql, "TIMESTAMP WITHOUT TIME ZONE")
+                        else:
+                            self.assertEqual(sql, f"TIMESTAMP({precision}) WITHOUT TIME ZONE")
+                    elif db_name in [None, "sqlite"]:
+                        if datatype == "timestamp":
+                            self.assertEqual(sql, "TIMESTAMP")
+                        elif datatype == "datetime":
+                            self.assertEqual(sql, "DATETIME")
+                    print("")
 
 
 class RedundantDatatypesTest(unittest.TestCase):


### PR DESCRIPTION
Changes:

- Add the datetime type to the Felis type system

- Establish reasonable defaults for datetime and timestamp types for MySQL and PostgreSQL

- Add `precision` and `timezone` column attributes to Pydantic data model

- Update the SQL output in `metadata` to set `precision` and `timezone` from the datamodel fields

- Add sample timestamp and datetime columns to the test schema

- Add tests of SQL output from `timestamp` and `datetime` types