### PR TITLE
DM-44825: Improve support for timestamp handling

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -141,6 +141,13 @@ class Column(BaseObject):
     length: int | None = Field(None, gt=0)
     """Length of the column."""
 
+    precision: int | None = Field(None, ge=0)
+    """The numerical precision of the column.
+
+    For timestamps, this is the number of fractional digits retained in the
+    seconds field.
+    """
+
     nullable: bool = True
     """Whether the column can be ``NULL``."""
 

--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -156,6 +156,11 @@ binary_map: _TypeMap = {
     POSTGRES: postgresql.BYTEA,
 }
 
+timestamp_map: _TypeMap = {
+    MYSQL: mysql.DATETIME,
+    POSTGRES: postgresql.TIMESTAMP,
+}
+
 
 def boolean(**kwargs: Any) -> types.TypeEngine:
     """Get the SQL type for Felis `~felis.types.Boolean` with variants.
@@ -370,7 +375,7 @@ def timestamp(**kwargs: Any) -> types.TypeEngine:
     `~sqlalchemy.types.TypeEngine`
         The SQL type for a Felis timestamp.
     """
-    return types.TIMESTAMP()
+    return _vary(types.TIMESTAMP(timezone=False), timestamp_map, kwargs)
 
 
 def get_type_func(type_name: str) -> Callable:

--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -157,8 +157,8 @@ binary_map: _TypeMap = {
 }
 
 timestamp_map: _TypeMap = {
-    MYSQL: mysql.DATETIME,
-    POSTGRES: postgresql.TIMESTAMP,
+    MYSQL: mysql.DATETIME(timezone=False),
+    POSTGRES: postgresql.TIMESTAMP(timezone=False),
 }
 
 

--- a/python/felis/metadata.py
+++ b/python/felis/metadata.py
@@ -61,9 +61,7 @@ def _handle_timestamp(
     """Handle timezone and precision for timestamp types."""
     args.append(False)  # Timezone handling is always hard-coded to off.
     if column_obj.precision:
-        logger.debug(
-            "Setting timestamp precision on column '%s' to %d", (column_obj.id, column_obj.precision)
-        )
+        logger.debug("Setting timestamp precision on column '%s' to %d", column_obj.id, column_obj.precision)
         args.append(column_obj.precision)  # Precision is always the second argument, if provided.
     variant_dict.update({"postgresql": postgresql.TIMESTAMP(*args), "mysql": mysql.DATETIME(*args)})
     logger.debug("Updated variant dict with timestamp: %s", variant_dict)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -664,7 +664,7 @@ class RedundantDatatypesTest(unittest.TestCase):
             coldata.col("unicode", "NVARCHAR", length=32)
 
         with self.assertRaises(ValidationError):
-            coldata.col("timestamp", "TIMESTAMP")
+            coldata.col("timestamp", "DATETIME")
 
         # DM-42257: Felis does not handle unbounded text types properly.
         # coldata.col("text", "TEXT", length=32)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -188,6 +188,28 @@ class MetaDataTestCase(unittest.TestCase):
                 for primary_key in primary_keys:
                     self.assertTrue(md_table.columns[primary_key].primary_key)
 
+    def test_timestamp(self):
+        """Test that the `timestamp` datatype is created correctly."""
+        for precision in [None, 6]:
+            col = dm.Column(
+                **{
+                    "name": "timestamp_test",
+                    "id": "#timestamp_test",
+                    "datatype": "timestamp",
+                    "precision": precision,
+                }
+            )
+            datatype = get_datatype_with_variants(col)
+            variant_dict = datatype._variant_mapping
+            self.assertTrue("mysql" in variant_dict)
+            self.assertTrue("postgresql" in variant_dict)
+            pg_timestamp = variant_dict["postgresql"]
+            self.assertEqual(pg_timestamp.timezone, False)
+            self.assertEqual(pg_timestamp.precision, precision)
+            mysql_timestamp = variant_dict["mysql"]
+            self.assertEqual(mysql_timestamp.timezone, False)
+            self.assertEqual(mysql_timestamp.fsp, precision)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implement improvements to timestamps as described in [RFC-1027](https://rubinobs.atlassian.net/browse/RFC-1027):

- Set `timezone=False` when instantiating timestamp types
- Introduce a `precision` attribute on the `Column` data model
- Map the Felis timestamp type to `DATETIME` in MySQL

[RFC-1027]: https://rubinobs.atlassian.net/browse/RFC-1027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ