### PR TITLE
Added size to TAP_SCHEMA.columns / Modify SQLWrite to handle mysql writes

### DIFF
--- a/python/felis/db/utils.py
+++ b/python/felis/db/utils.py
@@ -141,9 +141,18 @@ class SQLWriter:
         The functions arguments are typed very loosely because this method in
         SQLAlchemy is untyped, amd we do not call it directly.
         """
+        param_styles = {
+            'postgresql': 'named',
+            'sqlite': 'named',
+            'mysql': 'positional',
+            'oracle': 'named',
+            'mssql': 'named',
+        }
+
         compiled = sql.compile(dialect=self.dialect)
         sql_str = str(compiled) + ";"
         params_list = [compiled.params]
+
         for params in params_list:
             if not params:
                 print(sql_str, file=self.file)
@@ -156,7 +165,13 @@ class SQLWriter:
                     new_params[key] = "null"
                 else:
                     new_params[key] = value
-            print(sql_str % new_params, file=self.file)
+
+            param_style = param_styles.get(self.dialect.name, 'positional')
+            if param_style == 'named':
+                formatted_sql = sql_str % new_params
+            else:
+                formatted_sql = sql_str % tuple(new_params.values())
+            print(formatted_sql, file=self.file)
 
 
 class ConnectionWrapper:

--- a/python/felis/tap.py
+++ b/python/felis/tap.py
@@ -124,8 +124,7 @@ def init_tables(
         datatype = Column(String(SIMPLE_FIELD_LENGTH), nullable=False)
         arraysize = Column(String(10))
         xtype = Column(String(SIMPLE_FIELD_LENGTH))
-        # Size is deprecated
-        # size = Column(Integer(), quote=True)
+        size = Column(Integer(), name="size", quote=True)
         description = Column(String(TEXT_FIELD_LENGTH))
         utype = Column(String(SIMPLE_FIELD_LENGTH))
         unit = Column(String(SIMPLE_FIELD_LENGTH))
@@ -412,7 +411,7 @@ class TapLoadingVisitor:
         if felis_type.is_timestamp:
             arraysize = column_obj.votable_arraysize or "*"
         column.arraysize = arraysize
-
+        column.size = arraysize if arraysize is not "*" else None
         column.xtype = column_obj.votable_xtype
         column.description = column_obj.description
         column.utype = column_obj.votable_utype


### PR DESCRIPTION
**Summary**

Add size value to the TAP_SCHEMA column entries that get inserted. This addresses the issue where validators expect the "size" column to match the "arraysize" col.
The second change is to modify the engine-url to "mysql+mysqlconnector", as the TAP_SCHEMA database currently deployed is in MySQL, so the insert statements need to be produced for that as far as I can see. I noticed this after trying to add values for the size column, which produced invalid SQL statements.

**Jira issue:**

https://rubinobs.atlassian.net/browse/DM-44878

**How was this tested**

- Tested in combination with sdm_schemas PR: https://github.com/lsst/sdm_schemas/pull/237 on data-dev, using a custom Docker image built locally.
- Test run using stilts taplint

_Feel free to close PR or request modifications if you were planning on addressing this a different way. This is just a suggestion based on some experiments I was doing in the process of experimenting with the validation tools._