### PR TITLE
DM-44825: Check that precision is only allowed for timestamp columns

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -370,6 +370,19 @@ class Column(BaseObject):
                     )
         return self
 
+    @model_validator(mode="after")
+    def check_precision(self) -> Column:
+        """Check that precision is only valid for timestamp columns.
+
+        Returns
+        -------
+        `Column`
+            The column being validated.
+        """
+        if self.precision is not None and self.datatype != "timestamp":
+            raise ValueError("Precision is only valid for timestamp columns")
+        return self
+
 
 class Constraint(BaseObject):
     """Table constraint model."""

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -689,6 +689,13 @@ class RedundantDatatypesTest(unittest.TestCase):
         coldata.col("string", "CHAR", length=32)
         coldata.col("unicode", "CHAR", length=32)
 
+    def test_precision(self) -> None:
+        """Test that precision is not allowed for datatypes other than
+        timestamp.
+        """
+        with self.assertRaises(ValidationError):
+            Column(**{"name": "testColumn", "@id": "#test_col_id", "datatype": "double", "precision": 6})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `precision` field is used for specifying the precision of the seconds component on timestamp columns and is disallowed for all other datatypes.

This is an extra check on the data model added as part of [DM-44825](https://rubinobs.atlassian.net/browse/DM-44825), which improves timestamp support in Felis.

[DM-44825]: https://rubinobs.atlassian.net/browse/DM-44825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ