### PR TITLE
DM-44878: Fill in the TAP_SCHEMA size attribute

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from enum import StrEnum, auto
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Any, TypeAlias
 
 from astropy import units as units  # type: ignore
 from astropy.io.votable import ucd  # type: ignore
@@ -178,7 +178,7 @@ class Column(BaseObject):
     tap_principal: int | None = Field(0, alias="tap:principal", ge=0, le=1)
     """Whether this is a TAP_SCHEMA principal column."""
 
-    votable_arraysize: int | Literal["*"] | None = Field(None, alias="votable:arraysize")
+    votable_arraysize: int | str | None = Field(None, alias="votable:arraysize")
     """VOTable arraysize of the column."""
 
     tap_std: int | None = Field(0, alias="tap:std", ge=0, le=1)

--- a/tests/test_tap.py
+++ b/tests/test_tap.py
@@ -23,8 +23,6 @@ import os
 import shutil
 import tempfile
 import unittest
-from collections.abc import MutableMapping
-from typing import Any
 
 import sqlalchemy
 import yaml
@@ -39,7 +37,7 @@ TEST_YAML = os.path.join(TESTDIR, "data", "test.yml")
 class VisitorTestCase(unittest.TestCase):
     """Test the TAP loading visitor."""
 
-    schema_obj: MutableMapping[str, Any] = {}
+    schema_obj: Schema
 
     def setUp(self) -> None:
         """Load data from a test file."""


### PR DESCRIPTION
- Set the `size` attribute based on the value of `votable_arraysize` from the column
    - If arraysize is an int in the YAML data or a string that is parseable as an int, set size=arraysize
    - If arraysize has the form "N*" where N is an int, set size=N
    - For all other cases, size will default to `None` which will result in a null being inserted. This includes the case where arraysize is `*` or a blank string.
- Change the `votable_arraysize` field on the Pydantic model to accept a string or an integer
    - The field was too restrictive based on the valid values from the IVOA VOTable standard.
- Fix bad type hint in `test_tap`