### PR TITLE
DM-45191: Remove support for Oracle database dialect and data types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ validity using an internal `Pydantic <https://docs.pydantic.dev/latest/>`_ data
 model to ensure strict conformance to the format. SQL Data Definition language
 (DDL) statements can be generated to instantiate corresponding database
 objects, such as tables and columns, in a number of different database
-variants, including MySQL, PostgreSQL, Oracle, and SQLite. The schema can also
+variants, including MySQL, PostgreSQL, and SQLite. The schema can also
 be used to update the TAP schema information in a
 `TAP <https://www.ivoa.net/documents/TAP/>`_ service.
 

--- a/python/felis/db/dialects.py
+++ b/python/felis/db/dialects.py
@@ -30,11 +30,11 @@ from sqlalchemy import dialects
 from sqlalchemy.engine import Dialect
 from sqlalchemy.engine.mock import create_mock_engine
 
-from .sqltypes import MYSQL, ORACLE, POSTGRES, SQLITE
+from .sqltypes import MYSQL, POSTGRES, SQLITE
 
 __all__ = ["get_supported_dialects", "get_dialect_module"]
 
-_DIALECT_NAMES = (MYSQL, POSTGRES, SQLITE, ORACLE)
+_DIALECT_NAMES = (MYSQL, POSTGRES, SQLITE)
 """List of supported dialect names.
 
 This list is used to create the dialect and module dictionaries.

--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -28,7 +28,7 @@ from collections.abc import Callable, Mapping
 from typing import Any
 
 from sqlalchemy import SmallInteger, types
-from sqlalchemy.dialects import mysql, oracle, postgresql
+from sqlalchemy.dialects import mysql, postgresql
 from sqlalchemy.ext.compiler import compiles
 
 __all__ = [
@@ -49,7 +49,6 @@ __all__ = [
 ]
 
 MYSQL = "mysql"
-ORACLE = "oracle"
 POSTGRES = "postgresql"
 SQLITE = "sqlite"
 
@@ -88,21 +87,18 @@ def compile_tinyint(type_: Any, compiler: Any, **kwargs: Any) -> str:
 
 _TypeMap = Mapping[str, types.TypeEngine | type[types.TypeEngine]]
 
-boolean_map: _TypeMap = {MYSQL: mysql.BOOLEAN, ORACLE: oracle.NUMBER(1), POSTGRES: postgresql.BOOLEAN()}
+boolean_map: _TypeMap = {MYSQL: mysql.BOOLEAN, POSTGRES: postgresql.BOOLEAN()}
 
 byte_map: _TypeMap = {
     MYSQL: mysql.TINYINT(),
-    ORACLE: oracle.NUMBER(3),
     POSTGRES: postgresql.SMALLINT(),
 }
 
 short_map: _TypeMap = {
     MYSQL: mysql.SMALLINT(),
-    ORACLE: oracle.NUMBER(5),
     POSTGRES: postgresql.SMALLINT(),
 }
 
-# Skip Oracle
 int_map: _TypeMap = {
     MYSQL: mysql.INTEGER(),
     POSTGRES: postgresql.INTEGER(),
@@ -110,49 +106,41 @@ int_map: _TypeMap = {
 
 long_map: _TypeMap = {
     MYSQL: mysql.BIGINT(),
-    ORACLE: oracle.NUMBER(38, 0),
     POSTGRES: postgresql.BIGINT(),
 }
 
 float_map: _TypeMap = {
     MYSQL: mysql.FLOAT(),
-    ORACLE: oracle.BINARY_FLOAT(),
     POSTGRES: postgresql.FLOAT(),
 }
 
 double_map: _TypeMap = {
     MYSQL: mysql.DOUBLE(),
-    ORACLE: oracle.BINARY_DOUBLE(),
     POSTGRES: postgresql.DOUBLE_PRECISION(),
 }
 
 char_map: _TypeMap = {
     MYSQL: mysql.CHAR,
-    ORACLE: oracle.CHAR,
     POSTGRES: postgresql.CHAR,
 }
 
 string_map: _TypeMap = {
     MYSQL: mysql.VARCHAR,
-    ORACLE: oracle.VARCHAR2,
     POSTGRES: postgresql.VARCHAR,
 }
 
 unicode_map: _TypeMap = {
     MYSQL: mysql.NVARCHAR,
-    ORACLE: oracle.NVARCHAR2,
     POSTGRES: postgresql.VARCHAR,
 }
 
 text_map: _TypeMap = {
     MYSQL: mysql.LONGTEXT,
-    ORACLE: oracle.CLOB,
     POSTGRES: postgresql.TEXT,
 }
 
 binary_map: _TypeMap = {
     MYSQL: mysql.LONGBLOB,
-    ORACLE: oracle.BLOB,
     POSTGRES: postgresql.BYTEA,
 }
 


### PR DESCRIPTION
Triggered by [RFC-1029](https://rubinobs.atlassian.net/browse/RFC-1029), remove support for Oracle datatypes and drop from supported database dialects.

This version of the user guide in `docs` is not modified, because it is being completely rewritten as part of [DM-43800](https://rubinobs.atlassian.net/browse/DM-43800), which removes mention of Oracle.

[RFC-1029]: https://rubinobs.atlassian.net/browse/RFC-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DM-43800]: https://rubinobs.atlassian.net/browse/DM-43800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ