### PR TITLE
Fix arraysize not being set for text columns

### DIFF
--- a/python/felis/tap.py
+++ b/python/felis/tap.py
@@ -406,12 +406,9 @@ class TapLoadingVisitor:
         felis_type = FelisType.felis_type(felis_datatype.value)
         column.datatype = column_obj.votable_datatype or felis_type.votable_name
 
-        arraysize = None
-        if felis_type.is_sized:
-            arraysize = column_obj.votable_arraysize or column_obj.length or "*"
-        if felis_type.is_timestamp:
-            arraysize = column_obj.votable_arraysize or "*"
-        column.arraysize = arraysize
+        column.arraysize = column_obj.votable_arraysize or column_obj.length
+        if (felis_type.is_timestamp or column_obj.datatype == "text") and column.arraysize is None:
+            column.arraysize = "*"
 
         column.xtype = column_obj.votable_xtype
         column.description = column_obj.description


### PR DESCRIPTION
Rewrite the logic for setting arraysize so that it is simpler and does not check if the Felis type is sized.

Instead set arraysize from the column or use it's length if arraysize is not set. For timestamp or text columns, set the arraysize to '*' if it was not set explicitly in the schema.