### PR TITLE
DM-45492: Change names of several create command options

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,11 +27,22 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
+      - name: Set up PostgreSQL
+        uses: Harmon758/postgresql-action@v1.0.0
+        with:
+          postgresql version: '16'
+
       - name: Install prereqs for setuptools
         run: pip install wheel
 
       - name: Install dependencies
         run: pip install -r requirements.txt
+
+      - name: Install psycopg2
+        run: pip install psycopg2
+
+      - name: Install testing.postgresql
+        run: pip install testing.postgresql
 
       # We have two cores so we can speed up the testing with xdist
       - name: Install pytest packages

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,38 +21,40 @@ jobs:
           # Need to clone everything for the git tags.
           fetch-depth: 0
 
+      - name: Set up PostgreSQL
+        uses: Harmon758/postgresql-action@v1.0.0
+        with:
+          postgresql version: '16'
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
-      - name: Set up PostgreSQL
-        uses: Harmon758/postgresql-action@v1.0.0
-        with:
-          postgresql version: '16'
-
       - name: Install prereqs for setuptools
         run: pip install wheel
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          python -m pip install --upgrade pip uv
+          uv pip install --system -r requirements.txt
 
       - name: Install psycopg2
-        run: pip install psycopg2
+        run: uv pip install --system psycopg2
 
       - name: Install testing.postgresql
-        run: pip install testing.postgresql
+        run: uv pip install --system testing.postgresql
 
       # We have two cores so we can speed up the testing with xdist
       - name: Install pytest packages
-        run: pip install pytest pytest-xdist pytest-cov
+        run: uv pip install --system pytest pytest-xdist pytest-cov
 
       - name: List installed packages
-        run: pip list -v
+        run: uv pip list -v
 
       - name: Build and install
-        run: pip install -v --no-deps -e .
+        run: uv pip install --system -v --no-deps -e .
 
       - name: Run tests
         run: pytest -r a -v -n 3 --cov=tests --cov=felis --cov-report=xml --cov-report=term --cov-branch

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+.PHONY: help build docs check test numpydoc mypy all
+
+MAKEFLAGS += --no-print-directory
+
+help:
+	@echo "Available targets for Felis:"
+	@echo "  build    - Build the package"
+	@echo "  docs     - Generate the documentation"
+	@echo "  check    - Run pre-commit checks"
+	@echo "  test     - Run tests"
+	@echo "  numpydoc - Check numpydoc style"
+	@echo "  mypy     - Run mypy static type checker"
+	@echo "  all      - Run all tasks"
+
+build docs check test numpydoc mypy: print_target
+
+print_target:
+	@echo "Executing $(MAKECMDGOALS)..."
+
+build:
+	@uv pip install --force-reinstall --no-deps -e .
+
+docs:
+	@rm -rf docs/dev/internals docs/_build
+	@tox -e docs
+
+check:
+	@pre-commit run --all-files
+
+test:
+	@pytest -s --log-level DEBUG
+
+numpydoc:
+	@python -m numpydoc.hooks.validate_docstrings $(shell find python -name "*.py" ! -name "cli.py")
+
+mypy:
+	@mypy python/
+
+all:
+	@$(MAKE) build
+	@$(MAKE) docs
+	@$(MAKE) check
+	@$(MAKE) test
+	@$(MAKE) numpydoc
+	@$(MAKE) mypy
+	@echo "All tasks completed."

--- a/docs/dev/internals.rst
+++ b/docs/dev/internals.rst
@@ -33,3 +33,7 @@ Python API
 .. automodapi:: felis.db.variants
    :include-all-objects:
    :no-inheritance-diagram:
+
+.. automodapi:: felis.tests.postgresql
+    :include-all-objects:
+    :no-inheritance-diagram:

--- a/docs/user-guide/databases.rst
+++ b/docs/user-guide/databases.rst
@@ -142,19 +142,17 @@ Creating a New Database
 -----------------------
 
 Felis can also be used to create the database itself, rather than use an existing one, by using the
-``--create-if-not-exists`` option.
-
-Here is an example of creating a new MySQL database:
+``--initialize`` option:
 
 .. code-block:: bash
 
-    felis create --engine-url mysql+mysqlconnector://username:password@localhost --create-if-not-exists schema.yaml
+    felis create --engine-url mysql+mysqlconnector://username:password@localhost --initialize schema.yaml
 
 Felis can also drop an existing database first and then recreate it:
 
 .. code-block:: bash
 
-    felis create --engine-url mysql+mysqlconnector://username:password@localhost --drop-if-exists schema.yaml
+    felis create --engine-url mysql+mysqlconnector://username:password@localhost --drop schema.yaml
 
 The commands to create or drop databases will require that the database user has the necessary permissions on
 the server.
@@ -211,9 +209,9 @@ supports creation of the database or schema itself:
 
         engine = create_engine("mysql+mysqlconnector://username:password@localhost")
         ctx = DatabaseContext(metadata, engine)
-        ctx.create_if_not_exists()
+        ctx.initialize()
         ctx.create_all()
 
 An advantage of using this class is that it can automatically handle the creation of the database if it does
-not already exist with the ``create_if_not_exists`` method; an existing database may also be dropped and
-recreated using the ``drop_and_create`` method.
+not already exist with the ``create_if_not_exists`` method or drop and recreate the database with the
+``drop_and_create`` method.

--- a/docs/user-guide/databases.rst
+++ b/docs/user-guide/databases.rst
@@ -138,21 +138,38 @@ To show the tables which were instantiated, use the following command from withi
 
 SQLite will ignore the name of the schema, as it does not support named schemas or databases.
 
-Creating a New Database
------------------------
+Initializing and Dropping Databases
+-----------------------------------
 
-Felis can also be used to create the database itself, rather than use an existing one, by using the
-``--initialize`` option:
+Felis can create the schema's database, rather than use an existing one, with the ``--initialize`` option:
 
 .. code-block:: bash
 
     felis create --engine-url mysql+mysqlconnector://username:password@localhost --initialize schema.yaml
+
+If the database exists already, this command would raise an error to protect against inadvertant updates. To
+update an existing database, simply omit this option.
+
+Initialization is unneeded for SQLite, as a new database file will be created automatically if it does not
+exist, as in the following example:
+
+.. code-block:: bash
+
+    felis create --engine-url sqlite:///example.db schema.yaml
+
+In this case, the ``--initialize`` flag will be silently ignored if present.
 
 Felis can also drop an existing database first and then recreate it:
 
 .. code-block:: bash
 
     felis create --engine-url mysql+mysqlconnector://username:password@localhost --drop schema.yaml
+
+If the database does not exist, then the ``--drop`` option will be ignored and the database will be created
+normally.
+
+The ``--initialize`` and ``--drop`` options are mutually exclusive, as dropping always initializes the
+database. If they are used together then an error will be raised.
 
 The commands to create or drop databases will require that the database user has the necessary permissions on
 the server.

--- a/docs/user-guide/intro.rst
+++ b/docs/user-guide/intro.rst
@@ -22,4 +22,3 @@ Felis also provides a mechanism for instantiating a catalog from its schema repr
 relational database including the table, constraint and column definitions.
 This can be done using the command line interface or the Python API.
 Supported databases include SQLite, MySQL/MariaDB, and PostgreSQL.
-

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -165,8 +165,8 @@ def create(
 
         context.create_all()
     except Exception as e:
-        logger.error(e)
-        raise click.exceptions.Exit(1)
+        logger.exception(e)
+        raise click.ClickException(str(e))
 
 
 @cli.command("init-tap", help="Initialize TAP_SCHEMA objects in the database")

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -376,9 +376,9 @@ def validate(
     Raises
     ------
     click.exceptions.Exit
-        If any validation errors are found. The ``ValidationError`` which is
-        thrown when a schema fails to validate will be logged as an error
-        message.
+        Raised if any validation errors are found. The ``ValidationError``
+        which is thrown when a schema fails to validate will be logged as an
+        error message.
 
     Notes
     -----

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -73,7 +73,11 @@ def cli(log_level: str, log_file: str | None) -> None:
 @cli.command("create", help="Create database objects from the Felis file")
 @click.option("--engine-url", envvar="ENGINE_URL", help="SQLAlchemy Engine URL", default="sqlite://")
 @click.option("--schema-name", help="Alternate schema name to override Felis file")
-@click.option("--initialize", is_flag=True, help="Create the schema in the database if it does not exist")
+@click.option(
+    "--initialize",
+    is_flag=True,
+    help="Create the schema in the database if it does not exist (error if already exists)",
+)
 @click.option(
     "--drop", is_flag=True, help="Drop schema if it already exists in the database (implies --initialize)"
 )
@@ -113,14 +117,6 @@ def create(
         Write SQL commands to a file instead of executing.
     file
         Felis file to read.
-
-    Notes
-    -----
-    This command creates database objects from the Felis file. The
-    ``--initialize`` or ``--drop`` flags can be used to create a new MySQL
-    database or PostgreSQL schema if it does not exist already. These options
-    are mutually exclusive and an error will be raised if they are used
-    together, because ``--drop`` always implies ``--initialize``.
     """
     try:
         yaml_data = yaml.safe_load(file)

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -253,7 +253,7 @@ class Column(BaseObject):
         Raises
         ------
         ValueError
-            If both FITS and IVOA units are provided, or if the unit is
+            Raised If both FITS and IVOA units are provided, or if the unit is
             invalid.
         """
         fits_unit = self.fits_tunit
@@ -289,7 +289,7 @@ class Column(BaseObject):
         Raises
         ------
         ValueError
-            If a length is not provided for a sized type.
+            Raised if a length is not provided for a sized type.
         """
         datatype = values.get("datatype")
         if datatype is None:
@@ -326,7 +326,7 @@ class Column(BaseObject):
         Raises
         ------
         ValueError
-            If a datatype override is redundant.
+            Raised if a datatype override is redundant.
         """
         context = info.context
         if not context or not context.get("check_redundant_datatypes", False):
@@ -445,8 +445,8 @@ class Index(BaseObject):
         Raises
         ------
         ValueError
-            If both columns and expressions are specified, or if neither are
-            specified.
+            Raised if both columns and expressions are specified, or if neither
+            are specified.
         """
         if "columns" in values and "expressions" in values:
             raise ValueError("Defining columns and expressions is not valid")
@@ -547,7 +547,7 @@ class Table(BaseObject):
         Raises
         ------
         ValueError
-            If column names are not unique.
+            Raised if column names are not unique.
         """
         if len(columns) != len(set(column.name for column in columns)):
             raise ValueError("Column names must be unique")
@@ -570,7 +570,7 @@ class Table(BaseObject):
         Raises
         ------
         ValueError
-            If the table is missing a TAP table index.
+            Raised If the table is missing a TAP table index.
         """
         context = info.context
         if not context or not context.get("check_tap_table_indexes", False):
@@ -597,7 +597,7 @@ class Table(BaseObject):
         Raises
         ------
         ValueError
-            If the table is missing a column flagged as 'principal'.
+            Raised if the table is missing a column flagged as 'principal'.
         """
         context = info.context
         if not context or not context.get("check_tap_principal", False):
@@ -741,7 +741,7 @@ class Schema(BaseObject):
         Raises
         ------
         ValueError
-            If table names are not unique.
+            Raised if table names are not unique.
         """
         if len(tables) != len(set(table.name for table in tables)):
             raise ValueError("Table names must be unique")
@@ -779,7 +779,7 @@ class Schema(BaseObject):
         Raises
         ------
         ValueError
-            If duplicate IDs are found in the schema.
+            Raised if duplicate identifiers are found in the schema.
 
         Notes
         -----
@@ -826,7 +826,7 @@ class Schema(BaseObject):
         Raises
         ------
         KeyError
-            If the object with the given ID is not found in the schema.
+            Raised if the object with the given ID is not found in the schema.
         """
         if id not in self:
             raise KeyError(f"Object with ID '{id}' not found in schema")

--- a/python/felis/db/dialects.py
+++ b/python/felis/db/dialects.py
@@ -109,7 +109,7 @@ def get_dialect_module(dialect_name: str) -> ModuleType:
     Raises
     ------
     ValueError
-        If the dialect name is not supported.
+        Raised if the dialect name is not supported.
     """
     if dialect_name not in _DIALECT_MODULES:
         raise ValueError(f"Unsupported dialect: {dialect_name}")

--- a/python/felis/db/sqltypes.py
+++ b/python/felis/db/sqltypes.py
@@ -383,7 +383,7 @@ def get_type_func(type_name: str) -> Callable:
     Raises
     ------
     ValueError
-        If the type name is not recognized.
+        Raised if the type name is not recognized.
 
     Notes
     -----

--- a/python/felis/db/utils.py
+++ b/python/felis/db/utils.py
@@ -260,8 +260,6 @@ class DatabaseContext:
                     raise ValueError(f"PostgreSQL schema '{schema_name}' already exists.")
                 logger.debug(f"Creating PG schema: {schema_name}")
                 self.conn.execute(CreateSchema(schema_name))
-            else:
-                raise ValueError("Unsupported database type: " + self.dialect_name)
         except SQLAlchemyError as e:
             logger.error(f"Error creating schema: {e}")
             raise

--- a/python/felis/db/utils.py
+++ b/python/felis/db/utils.py
@@ -70,7 +70,7 @@ def string_to_typeengine(
     Raises
     ------
     ValueError
-        If the type string is invalid or the type is not supported.
+        Raised if the type string is invalid or the type is not supported.
 
     Notes
     -----
@@ -226,9 +226,9 @@ class DatabaseContext:
         Raises
         ------
         ValueError
-            If the database is not supported or it already exists.
+            Raised if the database is not supported or it already exists.
         sqlalchemy.exc.SQLAlchemyError
-            If there is an error creating the schema.
+            Raised if there is an error creating the schema.
 
         Notes
         -----
@@ -277,7 +277,7 @@ class DatabaseContext:
         Raises
         ------
         ValueError
-            If the database is not supported.
+            Raised if the database is not supported.
 
         Notes
         -----

--- a/python/felis/db/variants.py
+++ b/python/felis/db/variants.py
@@ -82,7 +82,7 @@ def _get_column_variant_override(field_name: str) -> str:
     Raises
     ------
     ValueError
-        If the field name is not found in the column variant overrides.
+        Raised if the field name is not found in the column variant overrides.
     """
     if field_name not in _COLUMN_VARIANT_OVERRIDES:
         raise ValueError(f"Field name {field_name} not found in column variant overrides")
@@ -111,7 +111,7 @@ def _process_variant_override(dialect_name: str, variant_override_str: str) -> t
     Raises
     ------
     ValueError
-        If the type is not found in the dialect.
+        Raised if the type is not found in the dialect.
 
     Notes
     -----

--- a/python/felis/metadata.py
+++ b/python/felis/metadata.py
@@ -94,8 +94,8 @@ def get_datatype_with_variants(column_obj: datamodel.Column) -> TypeEngine:
     Raises
     ------
     ValueError
-        If the column has a sized type but no length or if the datatype is
-        invalid.
+        Raised if the column has a sized type but no length or if the datatype
+        is invalid.
     """
     variant_dict = make_variant_dict(column_obj)
     felis_type = FelisType.felis_type(column_obj.datatype.value)

--- a/python/felis/tests/postgresql.py
+++ b/python/felis/tests/postgresql.py
@@ -1,0 +1,134 @@
+"""Provides a temporary Postgresql instance for testing."""
+
+# This file is part of felis.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import gc
+import unittest
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection, Engine, create_engine
+
+try:
+    from testing.postgresql import Postgresql  # type: ignore
+except ImportError:
+    Postgresql = None
+
+__all__ = ["TemporaryPostgresInstance", "setup_postgres_test_db"]
+
+
+class TemporaryPostgresInstance:
+    """Wrapper for a temporary Postgres database.
+
+    Parameters
+    ----------
+    server
+        The ``testing.postgresql.Postgresql`` instance.
+    engine
+        The SQLAlchemy engine for the temporary database server.
+
+    Notes
+    -----
+    This class was copied and modified from
+    ``lsst.daf.butler.tests.postgresql``.
+    """
+
+    def __init__(self, server: Postgresql, engine: Engine) -> None:
+        """Initialize the temporary Postgres database instance."""
+        self._server = server
+        self._engine = engine
+
+    @property
+    def url(self) -> str:
+        """Return connection URL for the temporary database server.
+
+        Returns
+        -------
+        str
+            The connection URL.
+        """
+        return self._server.url()
+
+    @property
+    def engine(self) -> Engine:
+        """Return the SQLAlchemy engine for the temporary database server.
+
+        Returns
+        -------
+        `~sqlalchemy.engine.Engine`
+            The SQLAlchemy engine.
+        """
+        return self._engine
+
+    @contextmanager
+    def begin(self) -> Iterator[Connection]:
+        """Return a SQLAlchemy connection to the test database.
+
+        Returns
+        -------
+        `~sqlalchemy.engine.Connection`
+            The SQLAlchemy connection.
+        """
+        with self._engine.begin() as connection:
+            yield connection
+
+    def print_info(self) -> None:
+        """Print information about the temporary database server."""
+        print("\n\n---- PostgreSQL URL ----")
+        print(self.url)
+        self._engine = create_engine(self.url)
+        with self.begin() as conn:
+            print("\n---- PostgreSQL Version ----")
+            res = conn.execute(text("SELECT version()")).fetchone()
+            if res:
+                print(res[0])
+            print("\n")
+
+
+@contextmanager
+def setup_postgres_test_db() -> Iterator[TemporaryPostgresInstance]:
+    """Set up a temporary Postgres database instance that can be used for
+    testing.
+
+    Returns
+    -------
+    TemporaryPostgresInstance
+        The temporary Postgres database instance.
+
+    Raises
+    ------
+    unittest.SkipTest
+        Raised if the ``testing.postgresql`` module is not available.
+    """
+    if Postgresql is None:
+        raise unittest.SkipTest("testing.postgresql module not available.")
+
+    with Postgresql() as server:
+        engine = create_engine(server.url())
+        instance = TemporaryPostgresInstance(server, engine)
+        yield instance
+
+        # Clean up any lingering SQLAlchemy engines/connections
+        # so they're closed before we shut down the server.
+        gc.collect()
+        engine.dispose()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,6 +123,16 @@ class CliTestCase(unittest.TestCase):
         )
         self.assertEqual(result.exit_code, 0)
 
+    def test_initialize_and_drop(self) -> None:
+        """Test that initialize and drop can't be used together."""
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["create", "--initialize", "--drop", TEST_YAML],
+            catch_exceptions=False,
+        )
+        self.assertTrue(result.exit_code != 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -1,0 +1,89 @@
+# This file is part of felis.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+import yaml
+from sqlalchemy import text
+
+from felis.datamodel import Schema
+from felis.db.utils import DatabaseContext
+from felis.metadata import MetaDataBuilder
+from felis.tests.postgresql import TemporaryPostgresInstance, setup_postgres_test_db  # type: ignore
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+TEST_YAML = os.path.join(TESTDIR, "data", "sales.yaml")
+
+
+class TestPostgresql(unittest.TestCase):
+    """Test PostgreSQL database setup."""
+
+    postgresql: TemporaryPostgresInstance
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Create the postgres test server.
+        cls.postgresql = cls.enterClassContext(setup_postgres_test_db())
+        super().setUpClass()
+
+    def test_initialize_create_and_drop(self) -> None:
+        """Test database initialization, creation, and deletion in
+        PostgreSQL.
+        """
+        # Create the schema and metadata
+        yaml_data = yaml.safe_load(open(TEST_YAML))
+        schema = Schema.model_validate(yaml_data)
+        md = MetaDataBuilder(schema).build()
+
+        # Initialize the database
+        ctx = DatabaseContext(md, self.postgresql.engine)
+        ctx.initialize()
+        ctx.create_all()
+
+        # Get the names of the tables without the schema prepended
+        table_names = [name.split(".")[-1] for name in md.tables.keys()]
+
+        # Check that the tables and columns are created
+        with self.postgresql.begin() as conn:
+            res = conn.execute(text("SELECT table_name FROM information_schema.tables"))
+            tables = [row[0] for row in res.fetchall()]
+            for table_name in table_names:
+                self.assertIn(table_name, tables)
+                # Check that all columns are created
+                expected_columns = [col.name for col in md.tables[f"sales.{table_name}"].columns]
+                res = conn.execute(
+                    text("SELECT column_name FROM information_schema.columns WHERE table_name = :table_name"),
+                    {"table_name": table_name},
+                )
+                actual_columns = [row[0] for row in res.fetchall()]
+                self.assertSetEqual(set(expected_columns), set(actual_columns))
+
+        # Drop the schema
+        ctx.drop()
+
+        # Check that the "sales" schema was dropped
+        with self.postgresql.begin() as conn:
+            res = conn.execute(
+                text("SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'sales'")
+            )
+            schemas = [row[0] for row in res.fetchall()]
+            self.assertNotIn("sales", schemas)


### PR DESCRIPTION
Change `--create-if-not-exists` option to `--initialize` and throw an error if the schema already exists in the database. To update an existing database, this option should be omitted. This flag will be ignored for SQLite, as tables can be created in a new database file automatically provided that the engine URL is valid.

Change `--drop-if-exists` option to `--drop`. This will drop and then recreate a schema if it exists. If the schema does not exist, then this is a no-op.

The `--drop` and `--initialize` options were made mutually exclusive and an error will be throw if they are used together. The `--drop` flag always activates initialization, as the database needs to be recreated if it was dropped or does not exist.

Add drop operation support for SQLite, which will remove all the relevant tables from `main` if not in dry run mode.

Add some simple tests of database functionality using `testing.postgresql`. The `TemporaryPostgresInstance` class used for these tests was copied from `daf_butler` and modified, as indicated in the class docstring.

Add a test to `test_cli` which checks that the two new options are mutually exclusive.

Add a Makefile with some convenient commands for local development.

Make a minor change to `cli` so that exceptions in the `create` command are caught and rethrown as a `ClickException`.

Update the Github `build` workflow to install a PostgreSQL testing environment and use `uv` for `pip` commands.

Update the user guide with the new option names.