### PR TITLE
DM-45725: Change default table engine to MyISAM

### DIFF
--- a/docs/user-guide/databases.rst
+++ b/docs/user-guide/databases.rst
@@ -93,6 +93,9 @@ To create a MySQL database from a schema file, the command would look similar to
 
 In this case, the database would already need to have been created or the command will fail.
 
+Tables in MySQL will by default use the ``MyISAM`` storage engine, which does not support foreign keys.
+The engine can be changed in the table object of the schema by setting ``mysql:engine`` to ``InnoDB`` or another valid table engine name.
+
 PostgreSQL
 ^^^^^^^^^^
 

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -492,7 +492,7 @@ class Table(BaseObject):
     tap_table_index: int | None = Field(None, alias="tap:table_index")
     """IVOA TAP_SCHEMA table index of the table."""
 
-    mysql_engine: str | None = Field(None, alias="mysql:engine")
+    mysql_engine: str | None = Field("MyISAM", alias="mysql:engine")
     """MySQL engine to use for the table."""
 
     mysql_charset: str | None = Field(None, alias="mysql:charset")


### PR DESCRIPTION
Change the default MySQL table engine to MyISAM in the data model, for two main reasons:

- This is the table engine used by Qserv, so we want to match it as closely as possible.
- Some of the tables are exceeding the maximum number of columns allowed by the InnoDB engine.

