### PR TITLE
DM-46002: Locations for validation errors on constraints reported incorrectly

### DIFF
--- a/docs/changes/DM-46002.bugfix.rst
+++ b/docs/changes/DM-46002.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where the error locations on constraint objects during validation were reported incorrectly.
+This was accomplished by replacing the ``create_constraints()`` function with a Pydantic `discriminated union <https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions-with-str-discriminators>`__.

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -394,6 +394,20 @@ class Constraint(BaseObject):
     """Value for ``INITIALLY`` clause; only used if `deferrable` is
     `True`."""
 
+    @model_validator(mode="after")
+    def check_deferrable(self) -> Constraint:
+        """Check that the ``INITIALLY`` clause is only used if `deferrable` is
+        `True`.
+
+        Returns
+        -------
+        `Constraint`
+            The constraint being validated.
+        """
+        if self.initially is not None and not self.deferrable:
+            raise ValueError("INITIALLY clause can only be used if deferrable is True")
+        return self
+
 
 class CheckConstraint(Constraint):
     """Table check constraint model."""

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -24,7 +24,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from enum import StrEnum, auto
 from typing import Annotated, Any, Literal, TypeAlias, Union
 
@@ -393,9 +393,6 @@ class Constraint(BaseObject):
     initially: str | None = None
     """Value for ``INITIALLY`` clause; only used if `deferrable` is
     `True`."""
-
-    annotations: Mapping[str, Any] = Field(default_factory=dict)
-    """Additional annotations for this constraint."""
 
 
 class CheckConstraint(Constraint):

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -390,7 +390,7 @@ class Constraint(BaseObject):
     deferrable: bool = False
     """Whether this constraint will be declared as deferrable."""
 
-    initially: str | None = None
+    initially: Literal["IMMEDIATE", "DEFERRED"] | None = None
     """Value for ``INITIALLY`` clause; only used if `deferrable` is
     `True`."""
 

--- a/python/felis/metadata.py
+++ b/python/felis/metadata.py
@@ -342,7 +342,6 @@ class MetaDataBuilder:
             "initially": constraint_obj.initially or None,
         }
         constraint: Constraint
-        constraint_type = constraint_obj.type
 
         if isinstance(constraint_obj, datamodel.ForeignKeyConstraint):
             fk_obj: datamodel.ForeignKeyConstraint = constraint_obj
@@ -358,7 +357,7 @@ class MetaDataBuilder:
             columns = [self._objects[column_id] for column_id in uniq_obj.columns]
             constraint = UniqueConstraint(*columns, **args)
         else:
-            raise ValueError(f"Unknown constraint type: {constraint_type}")
+            raise ValueError(f"Unknown constraint type: {type(constraint_obj)}")
 
         self._objects[constraint_obj.id] = constraint
 

--- a/python/felis/tap.py
+++ b/python/felis/tap.py
@@ -37,7 +37,7 @@ from sqlalchemy.sql.expression import Insert, insert
 
 from felis import datamodel
 
-from .datamodel import Constraint, Index, Schema, Table
+from .datamodel import Constraint, ForeignKeyConstraint, Index, Schema, Table
 from .types import FelisType
 
 __all__ = ["TapLoadingVisitor", "init_tables"]
@@ -480,10 +480,9 @@ class TapLoadingVisitor:
             A tuple of the SQLAlchemy ORM objects for the TAP_SCHEMA ``key``
             and ``key_columns`` data.
         """
-        constraint_type = constraint_obj.type
         key = None
         key_columns = []
-        if constraint_type == "ForeignKey":
+        if isinstance(constraint_obj, ForeignKeyConstraint):
             constraint_name = constraint_obj.name
             description = constraint_obj.description
             utype = constraint_obj.votable_utype

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -286,39 +286,6 @@ class ConstraintTestCase(unittest.TestCase):
         self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
         self.assertEqual(col.columns, ["testColumn"], "columns should be ['testColumn']")
 
-    def test_index_validation(self) -> None:
-        """Test validation of indexes."""
-        # Default initialization should throw an exception.
-        with self.assertRaises(ValidationError):
-            Index()
-
-        # Setting only name should throw an exception.
-        with self.assertRaises(ValidationError):
-            Index(name="testConstraint")
-
-        # Setting name and id should throw an exception from missing columns.
-        with self.assertRaises(ValidationError):
-            Index(name="testConstraint", id="#test_id")
-
-        # Setting name, id, and columns should not throw an exception and
-        # should load data correctly.
-        col = Index(name="testConstraint", id="#test_id", columns=["testColumn"])
-        self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
-        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
-        self.assertEqual(col.columns, ["testColumn"], "columns should be ['testColumn']")
-
-        # Creating from data dictionary should work and load data correctly.
-        data = {"name": "testConstraint", "id": "#test_id", "columns": ["testColumn"]}
-        col = Index(**data)
-        self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
-        self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
-        self.assertEqual(col.columns, ["testColumn"], "columns should be ['testColumn']")
-
-        # Setting both columns and expressions on an index should throw an
-        # exception.
-        with self.assertRaises(ValidationError):
-            Index(name="testConstraint", id="#test_id", columns=["testColumn"], expressions=["1+2"])
-
     def test_foreign_key_validation(self) -> None:
         """Test validation of foreign key constraints."""
         # Default initialization should throw an exception.
@@ -392,6 +359,43 @@ class ConstraintTestCase(unittest.TestCase):
         self.assertEqual(col.name, "testConstraint", "name should be 'testConstraint'")
         self.assertEqual(col.id, "#test_id", "id should be '#test_id'")
         self.assertEqual(col.expression, "1+2", "expression should be '1+2'")
+
+
+class IndexTestCase(unittest.TestCase):
+    """Test Pydantic validation of the ``Index`` class."""
+
+    def test_index_validation(self) -> None:
+        """Test validation of indexes."""
+        # Default initialization should throw an exception.
+        with self.assertRaises(ValidationError):
+            Index()
+
+        # Setting only name should throw an exception.
+        with self.assertRaises(ValidationError):
+            Index(name="idx_test")
+
+        # Setting name and id should throw an exception from missing columns.
+        with self.assertRaises(ValidationError):
+            Index(name="idx_test", id="#idx_test")
+
+        # Setting name, id, and columns should not throw an exception and
+        # should load data correctly.
+        idx = Index(name="idx_test", id="#idx_test", columns=["#test_column"])
+        self.assertEqual(idx.name, "idx_test", "name should be 'test_constraint'")
+        self.assertEqual(idx.id, "#idx_test", "id should be '#test_id'")
+        self.assertEqual(idx.columns, ["#test_column"], "columns should be ['test_column']")
+
+        # Creating from data dictionary should work and load data correctly.
+        data = {"name": "idx_test", "id": "#idx_test", "columns": ["test_column"]}
+        col = Index(**data)
+        self.assertEqual(col.name, "idx_test", "name should be 'idx_test'")
+        self.assertEqual(col.id, "#idx_test", "id should be '#idx_test'")
+        self.assertEqual(col.columns, ["test_column"], "columns should be ['test_column']")
+
+        # Setting both columns and expressions on an index should throw an
+        # exception.
+        with self.assertRaises(ValidationError):
+            Index(name="idx_test", id="#idx_test", columns=["test_column"], expressions=["1+2"])
 
 
 class SchemaTestCase(unittest.TestCase):


### PR DESCRIPTION
This fixes an issue where the Pydantic error locations for constraint objects were reported incorrectly, due to how the model objects were constructed.

Instead of using a custom `create_constraints()` function, a Pydantic [discriminated union](https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions-with-str-discriminators) was used to automatically construct the objects based on the `type` field. This seems to fix the issue where error locations were reported incorrectly.

Sample new error location is: `tables.0.constraints.0.Unique.@id`.

This is not exactly the same scheme that shows for some other types of objects, but it is at least clear now that the error has occurred in a specific constraint denoted by the index.

As a result of the above changes, usage of the `type` field in the `metadata` and `tap` modules was removed in favor of checking the constraint's type using `isinstance()`. This is required based on removal of the `type` field from the `Constraint` class. (Since it should never be instantiated, the `type` field is not needed on this class and including it creates typing conflicts with its child classes. Each constraint class now defines this separately and not as a common field from the parent class.)

A few additional changes were included which do not have associated tickets:

- Cleaned up the `Constraint` test case in `test_datamodel` (See https://github.com/lsst/felis/pull/102/commits/1706788efc2dda8f089c7d777d4fe7e5d9cb0935).
- Added check to the data model that the `deferrable` field on `Constraint` must be set to `True` if `initially` is not None. This requirement was indicated in comments but never implemented.
- Added a `Literal` to `Constraint` in the data model that limits the value of `initially` to `IMMEDIATE` or `DEFERRED` as these are the only valid values for an `INITIALLY` clause in DDL.
- Removed the unused `annotations` field on the `Constraint` class. (This field was erroneously carried over from the old "simple model" but has never been used within a production schema, to my knowledge.)
- Cleaned up the `Index` test case in `test_datamodel` (See https://github.com/lsst/felis/pull/102/commits/6631610d8da3dacf7b7952df773cfc5b43df34e2).

## Checklist

- [x] Ran Jenkins
- [x] Added a release note for user-visible changes to `docs/changes`
