### PR TITLE
Update towncrier title format

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,7 +1,5 @@
-:html_theme.sidebar_secondary.remove:
-
-Felis 27.0.0 2024-04-17
-=======================
+Felis 27.0.0 (2024-04-17)
+=========================
 
 New Features
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ felis = "felis.cli:cli"
     package_dir = "python"
     filename = "docs/CHANGES.rst"
     directory = "docs/changes"
-    title_format = "felis {version} {project_date}"
+    title_format = "felis {version} ({project_date})"
     issue_format = "`{issue} <https://jira.lsstcorp.org/browse/{issue}>`_"
 
 


### PR DESCRIPTION
This just updates the title format to put the date in parentheses in `CHANGES.rst` and in the `title_format` in `pyproject.toml`.

Also take out `:html_theme.sidebar_secondary.remove:` from `CHANGES.rst`. The sidebar will look fine when there are multiple releases.