### PR TITLE
DM-47804: Make release notes for v28

### DIFF
--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -1,5 +1,32 @@
-Felis 27.0.0 (2024-04-17)
-=========================
+#########
+Changelog
+#########
+
+v28.0.0 (2024-11-26)
+====================
+
+New Features
+------------
+
+- Added a new ``tap_schema`` module designed to deprecate and eventually replace the ``tap`` module.
+  This module provides utilities for translating a Felis schema into a TAP_SCHEMA representation.
+  The command ``felis load-tap-schema`` can be used to activate this functionality. (`DM-45263 <https://jira.lsstcorp.org/browse/DM-45263>`_)
+- Added a check to the data model which ensures that all constraint names are unique within the schema.
+  TAP_SCHEMA uses these names as primary keys in its ``keys`` table, so they cannot be duplicated. (`DM-45623 <https://jira.lsstcorp.org/browse/DM-45623>`_)
+- Added automatic ID generation for objects in Felis schemas when the ``--id-generation`` flag is included on the command line.
+  This is supported for the ``create`` and ``validate`` commands.
+  Also added a Schema validator function that checks if index names are unique. (`DM-45938 <https://jira.lsstcorp.org/browse/DM-45938>`_)
+
+
+Bug Fixes
+---------
+
+- Fixed a bug where the error locations on constraint objects during validation were reported incorrectly.
+  This was accomplished by replacing the ``create_constraints()`` function with a Pydantic `discriminated union <https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions-with-str-discriminators>`__. (`DM-46002 <https://jira.lsstcorp.org/browse/DM-46002>`_)
+
+
+v27.0.0 (2024-04-17)
+====================
 
 New Features
 ------------

--- a/docs/changes/DM-45263.feature.rst
+++ b/docs/changes/DM-45263.feature.rst
@@ -1,3 +1,0 @@
-Added a new ``tap_schema_`` module designed to deprecate and eventually replace the ``tap`` module.
-This module provides utilities for translating a Felis schema into a TAP_SCHEMA representation.
-The command ``felis load-tap-schema`` can be used to activate this functionality.

--- a/docs/changes/DM-45623.feature.rst
+++ b/docs/changes/DM-45623.feature.rst
@@ -1,2 +1,0 @@
-Added a check to the data model which ensures that all constraint names are unique within the schema.
-TAP_SCHEMA uses these names as primary keys in its ``keys`` table, so they cannot be duplicated.

--- a/docs/changes/DM-45938.feature.rst
+++ b/docs/changes/DM-45938.feature.rst
@@ -1,4 +1,0 @@
-Added automatic ID generation for objects in Felis schemas when the `--id-generation` flag is included on the command line.
-This is supported for the `create` and `validate` commands.
-
-Also added a Schema validator that checks if index names are unique.

--- a/docs/changes/DM-46002.bugfix.rst
+++ b/docs/changes/DM-46002.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed a bug where the error locations on constraint objects during validation were reported incorrectly.
-This was accomplished by replacing the ``create_constraints()`` function with a Pydantic `discriminated union <https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions-with-str-discriminators>`__.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,18 +5,33 @@ Felis
 
 Felis provides a system for describing astronomical data catalogs with a user-friendly YAML data format.
 It covers not only the metadata required to create database schemas, but also a wide range of additional
-metadata associated with IVOA standards and other applications.
+information associated with IVOA standards and other applications.
 While developed for the `Vera C. Rubin Observatory <https://rubinobservatory.org/>`__, which utilizes the
 framework for describing its `Science Data Model Schemas <https://github.com/lsst/sdm_schemas>`__, Felis is
 designed to be general enough to be used by any astronomical data provider.
 
-#############
-Documentation
-#############
+Felis is developed on GitHub at https://github.com/lsst/felis and is available on `PyPI <https://pypi.org/>`__ as ``lsst-felis``.
+
+User Guide
+==========
 
 .. toctree::
-    :maxdepth: 1
+   :maxdepth: 2
 
-    user-guide/index
-    dev/internals
-    Change Log <CHANGES.rst>
+   user-guide/index
+
+Python API
+==========
+
+.. toctree::
+   :maxdepth: 2
+
+   dev/internals
+
+Changelog
+=========
+
+.. toctree::
+   :maxdepth: 2
+
+   CHANGES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ felis = "felis.cli:cli"
     package_dir = "python"
     filename = "docs/CHANGES.rst"
     directory = "docs/changes"
-    title_format = "felis {version} ({project_date})"
+    title_format = "{version} ({project_date})"
     issue_format = "`{issue} <https://jira.lsstcorp.org/browse/{issue}>`_"
 
 


### PR DESCRIPTION
This PR includes the changelog for the `v28` middleware release, as well as some additional improvements to the Changelog and Index (landing page) of the Felis documentation site. The towncrier template was also updated to remove "felis" from the `title_format` so it just displays the release version and date.

## Checklist

- [ ] Ran Jenkins
- [ ] Added a release note for user-visible changes to `docs/changes`


