### PR TITLE
DM-45133: Set xtype on timestamp columns

### DIFF
--- a/docs/changes/DM-45133.feature
+++ b/docs/changes/DM-45133.feature
@@ -1,0 +1,1 @@
+Automatically set ``votable_xtype`` on timestamp columns to "timestamp", following the documentation in the VOTable REC on Extended Type (xtype).

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -504,6 +504,26 @@ class Column(BaseObject):
         """
         return DataType(value)
 
+    @model_validator(mode="after")
+    def check_votable_xtype(self) -> Column:
+        """Set the default value for the ``votable_xtype`` field, which
+        corresponds to an Extended Datatype or ``xtype`` in the IVOA VOTable
+        standard.
+
+        Returns
+        -------
+        `Column`
+            The column being validated.
+
+        Notes
+        -----
+        This is currently only set automatically for the Felis ``timestamp``
+        datatype.
+        """
+        if self.datatype == DataType.timestamp and self.votable_xtype is None:
+            self.votable_xtype = "timestamp"
+        return self
+
 
 class Constraint(BaseObject):
     """Table constraint model."""

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -231,6 +231,12 @@ class ColumnTestCase(unittest.TestCase):
         bool_coldata["value"] = True
         Column(**bool_coldata)
 
+    def test_timestamp(self) -> None:
+        """Test validation of timestamp columns."""
+        # Check that the votable_xtype is set correctly for timestamp columns.
+        col = Column(name="testColumn", id="#test_col_id", datatype="timestamp")
+        self.assertEqual(col.votable_xtype, "timestamp")
+
 
 class TableTestCase(unittest.TestCase):
     """Test Pydantic validation of the ``Table`` class."""


### PR DESCRIPTION
- Add a validator to automatically set the `votable_xtype` to "timestamp" on Felis timestamp columns.

## Checklist

- [x] Ran Jenkins
- [x] Added a release note for user-visible changes to `docs/changes`
