### PR TITLE
DM-47900: Add Python 3.13 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/changes/DM-47900.misc
+++ b/docs/changes/DM-47900.misc
@@ -1,0 +1,2 @@
+Add Python 3.13 to supported versions.
+No code changes were required.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Astronomy"
 ]
 keywords = ["lsst"]


### PR DESCRIPTION
Add Python 3.13 to the build matrix and supported versions.

This was separated from #109 by request of @gpdf.

## Checklist

- [x] Ran Jenkins
- [x] Added a release note for user-visible changes to `docs/changes`
