### PR TITLE
Add configuration to allow trusted PyPI publishing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,6 +76,8 @@ jobs:
   pypi:
     runs-on: ubuntu-latest
     needs: [build_and_test]
+    permissions:
+      id-token: write
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:


### PR DESCRIPTION
## Checklist

- [ ] Ran Jenkins
- [ ] Added a release note for user-visible changes to `docs/changes`
