### PR TITLE
Generate ids for column groups

### DIFF
--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -1041,6 +1041,14 @@ class Schema(BaseObject, Generic[T]):
                         if "@id" not in column:
                             column["@id"] = f"#{table['name']}.{column['name']}"
                             logger.debug(f"Generated ID '{column['@id']}' for column '{column['name']}'")
+                if "columnGroups" in table:
+                    for column_group in table["columnGroups"]:
+                        if "@id" not in column_group:
+                            column_group["@id"] = f"#{table['name']}.{column_group['name']}"
+                            logger.debug(
+                                f"Generated ID '{column_group['@id']}' for column group "
+                                f"'{column_group['name']}'"
+                            )
                 if "constraints" in table:
                     for constraint in table["constraints"]:
                         if "@id" not in constraint:

--- a/tests/data/test_id_generation.yaml
+++ b/tests/data/test_id_generation.yaml
@@ -12,6 +12,11 @@ tables:
     datatype: string
     description: Test column.
     length: 30
+  columnGroups:
+  - name: test_column_group
+    columns:
+    - "#test_table.test_column1"
+    - "#test_table.test_column2"
   indexes:
   - name: test_index
     columns:


### PR DESCRIPTION
The id generation was missing for column groups.

## Checklist

- [ ] Ran Jenkins
- [ ] Added a release note for user-visible changes to `docs/changes`
