### PR TITLE
DM-47602: Reorganize and refactor Felis CLI tests

### DIFF
--- a/docs/changes/DM-47602.misc.rst
+++ b/docs/changes/DM-47602.misc.rst
@@ -1,0 +1,2 @@
+Added a `tests.run_cli` utility module for running CLI commands in tests.
+Refactored the tests in ``tests_cli`` to use the new utility function.

--- a/docs/dev/internals.rst
+++ b/docs/dev/internals.rst
@@ -39,5 +39,9 @@ Python API
     :include-all-objects:
     :no-inheritance-diagram:
 
+.. automodapi:: felis.tests.run_cli
+    :include-all-objects:
+    :no-inheritance-diagram:
+
 .. automodapi:: felis.types
    :include-all-objects:

--- a/python/felis/tests/run_cli.py
+++ b/python/felis/tests/run_cli.py
@@ -1,0 +1,79 @@
+"""Test utility for running cli commands."""
+
+# This file is part of felis.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+
+from click.testing import CliRunner
+
+from felis.cli import cli
+
+__all__ = ["run_cli"]
+
+
+def run_cli(
+    cmd: list[str],
+    log_level: int = logging.WARNING,
+    catch_exceptions: bool = False,
+    expect_error: bool = False,
+    print_cmd: bool = False,
+    print_output: bool = False,
+    id_generation: bool = False,
+) -> None:
+    """Run a CLI command and check the exit code.
+
+    Parameters
+    ----------
+    cmd : list[str]
+        The command to run.
+    log_level : int
+        The logging level to use, by default logging.WARNING.
+    catch_exceptions : bool
+        Whether to catch exceptions, by default False.
+    expect_error : bool
+        Whether to expect an error, by default False.
+    print_cmd : bool
+        Whether to print the command, by default False.
+    print_output : bool
+        Whether to print the output, by default False.
+    id_generation : bool
+        Whether to enable id generation, by default False.
+    """
+    if not cmd:
+        raise ValueError("No command provided.")
+    full_cmd = ["--log-level", logging.getLevelName(log_level)] + cmd
+    if id_generation:
+        full_cmd = ["--id-generation"] + full_cmd
+    if print_cmd:
+        print(f"Running command: felis {' '.join(full_cmd)}")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        full_cmd,
+        catch_exceptions=catch_exceptions,
+    )
+    if print_output:
+        print(result.output)
+    if expect_error:
+        assert result.exit_code != 0
+    else:
+        assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,16 +24,15 @@ import shutil
 import tempfile
 import unittest
 
-from click.testing import CliRunner
 from sqlalchemy import create_engine
 
 import felis.tap_schema as tap_schema
-from felis.cli import cli
 from felis.datamodel import Schema
 from felis.metadata import MetaDataBuilder
+from felis.tests.run_cli import run_cli
 
-TESTDIR = os.path.abspath(os.path.dirname(__file__))
-TEST_YAML = os.path.join(TESTDIR, "data", "test.yml")
+TEST_DIR = os.path.abspath(os.path.dirname(__file__))
+TEST_YAML = os.path.join(TEST_DIR, "data", "test.yml")
 
 
 class CliTestCase(unittest.TestCase):
@@ -41,222 +40,142 @@ class CliTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up a temporary directory for tests."""
-        self.tmpdir = tempfile.mkdtemp(dir=TESTDIR)
+        self.tmpdir = tempfile.mkdtemp(dir=TEST_DIR)
+        self.sqlite_url = f"sqlite:///{self.tmpdir}/db.sqlite3"
+        print(f"Using temporary directory: {self.tmpdir}")
 
     def tearDown(self) -> None:
         """Clean up temporary directory."""
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    def test_create_all(self) -> None:
+    def test_invalid_command(self) -> None:
+        """Test for invalid command."""
+        run_cli(["invalid"], expect_error=True)
+
+    def test_help(self) -> None:
+        """Test for help command."""
+        run_cli(["--help"], print_output=True)
+
+    def test_create(self) -> None:
         """Test for create command."""
-        url = f"sqlite:///{self.tmpdir}/tap.sqlite3"
+        run_cli(["create", f"--engine-url={self.sqlite_url}", TEST_YAML])
 
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            ["create", "--schema-name=main", f"--engine-url={url}", TEST_YAML],
-            catch_exceptions=False,
-        )
-        self.assertEqual(result.exit_code, 0)
-
-    def test_create_all_dry_run(self) -> None:
+    def test_create_with_dry_run(self) -> None:
         """Test for ``create --dry-run`` command."""
-        url = f"sqlite:///{self.tmpdir}/tap.sqlite3"
+        run_cli(["create", "--schema-name=main", f"--engine-url={self.sqlite_url}", "--dry-run", TEST_YAML])
 
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            ["create", "--schema-name=main", f"--engine-url={url}", "--dry-run", TEST_YAML],
-            catch_exceptions=False,
-        )
-        self.assertEqual(result.exit_code, 0)
-
-    def test_ignore_constraints(self) -> None:
+    def test_create_with_ignore_constraints(self) -> None:
         """Test ``--ignore-constraints`` flag of ``create`` command."""
-        url = f"sqlite:///{self.tmpdir}/tap.sqlite3"
-
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
+        run_cli(
             [
                 "create",
                 "--schema-name=main",
                 "--ignore-constraints",
-                f"--engine-url={url}",
+                f"--engine-url={self.sqlite_url}",
                 "--dry-run",
                 TEST_YAML,
-            ],
-            catch_exceptions=False,
+            ]
         )
-        self.assertEqual(result.exit_code, 0)
 
-    def test_validate_default(self) -> None:
+    def test_validate(self) -> None:
         """Test validate command."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["validate", TEST_YAML], catch_exceptions=False)
-        self.assertEqual(result.exit_code, 0)
+        run_cli(["validate", TEST_YAML])
 
-    def test_id_generation(self) -> None:
+    def test_validate_with_id_generation(self) -> None:
         """Test the ``--id-generation`` flag."""
-        test_yaml = os.path.join(TESTDIR, "data", "test_id_generation.yaml")
-        runner = CliRunner()
-        result = runner.invoke(cli, ["--id-generation", "validate", test_yaml], catch_exceptions=False)
-        self.assertEqual(result.exit_code, 0)
+        test_yaml = os.path.join(TEST_DIR, "data", "test_id_generation.yaml")
+        run_cli(["--id-generation", "validate", test_yaml])
 
-    def test_no_id_generation(self) -> None:
+    def test_validate_with_id_validation_error(self) -> None:
         """Test that loading a schema without IDs fails if ID generation is not
         enabled.
         """
-        test_yaml = os.path.join(TESTDIR, "data", "test_id_generation.yaml")
-        runner = CliRunner()
-        result = runner.invoke(cli, ["validate", test_yaml], catch_exceptions=False)
-        self.assertNotEqual(result.exit_code, 0)
+        test_yaml = os.path.join(TEST_DIR, "data", "test_id_generation.yaml")
+        run_cli(["validate", test_yaml], expect_error=True)
 
-    def test_validation_flags(self) -> None:
+    def test_validate_with_extra_checks(self) -> None:
         """Test schema validation flags."""
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
+        run_cli(
             [
                 "validate",
                 "--check-description",
                 "--check-tap-principal",
                 "--check-tap-table-indexes",
                 TEST_YAML,
-            ],
-            catch_exceptions=False,
+            ]
         )
-        self.assertEqual(result.exit_code, 0)
 
-    def test_initialize_and_drop(self) -> None:
+    def test_create_with_initialize_and_drop_error(self) -> None:
         """Test that initialize and drop can't be used together."""
-        runner = CliRunner()
-        result = runner.invoke(
-            cli,
-            ["create", "--initialize", "--drop", TEST_YAML],
-            catch_exceptions=False,
-        )
-        self.assertTrue(result.exit_code != 0)
+        run_cli(["create", "--initialize", "--drop", TEST_YAML], expect_error=True)
 
     def test_load_tap_schema(self) -> None:
         """Test load-tap-schema command."""
         # Create the TAP_SCHEMA database.
-        url = f"sqlite:///{self.tmpdir}/load_tap_schema.sqlite3"
-        runner = CliRunner()
         tap_schema_path = tap_schema.TableManager.get_tap_schema_std_path()
-        result = runner.invoke(
-            cli,
-            ["--id-generation", "create", f"--engine-url={url}", tap_schema_path],
-            catch_exceptions=False,
-        )
-        self.assertEqual(result.exit_code, 0)
+        run_cli(["--id-generation", "create", f"--engine-url={self.sqlite_url}", tap_schema_path])
 
         # Load the TAP_SCHEMA data.
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["load-tap-schema", f"--engine-url={url}", TEST_YAML], catch_exceptions=False
-        )
-        self.assertEqual(result.exit_code, 0)
+        run_cli(["load-tap-schema", f"--engine-url={self.sqlite_url}", TEST_YAML])
 
     def test_init_tap_schema(self) -> None:
         """Test init-tap-schema command."""
-        url = f"sqlite:///{self.tmpdir}/init_tap_schema.sqlite3"
-        runner = CliRunner()
-        result = runner.invoke(cli, ["init-tap-schema", f"--engine-url={url}"], catch_exceptions=False)
-        self.assertEqual(result.exit_code, 0)
+        run_cli(["init-tap-schema", f"--engine-url={self.sqlite_url}"])
 
     def test_init_tap_schema_mock(self) -> None:
         """Test init-tap-schema command with a mock URL, which should throw
         an error, as this is not supported.
         """
-        runner = CliRunner()
-        result = runner.invoke(cli, ["init-tap-schema", "sqlite://"], catch_exceptions=False)
-        self.assertNotEqual(result.exit_code, 0)
+        run_cli(["init-tap-schema", "sqlite://"], expect_error=True)
 
     def test_diff(self) -> None:
         """Test for ``diff`` command."""
-        test_diff1 = os.path.join(TESTDIR, "data", "test_diff1.yaml")
-        test_diff2 = os.path.join(TESTDIR, "data", "test_diff2.yaml")
+        test_diff1 = os.path.join(TEST_DIR, "data", "test_diff1.yaml")
+        test_diff2 = os.path.join(TEST_DIR, "data", "test_diff2.yaml")
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ["diff", test_diff1, test_diff2], catch_exceptions=False)
-        self.assertEqual(result.exit_code, 0)
+        run_cli(["diff", test_diff1, test_diff2])
 
     def test_diff_database(self) -> None:
         """Test for ``diff`` command with database."""
-        test_diff1 = os.path.join(TESTDIR, "data", "test_diff1.yaml")
-        test_diff2 = os.path.join(TESTDIR, "data", "test_diff2.yaml")
-        db_url = f"sqlite:///{self.tmpdir}/tap_schema.sqlite3"
+        test_diff1 = os.path.join(TEST_DIR, "data", "test_diff1.yaml")
+        test_diff2 = os.path.join(TEST_DIR, "data", "test_diff2.yaml")
 
-        engine = create_engine(db_url)
+        engine = create_engine(self.sqlite_url)
         metadata_db = MetaDataBuilder(Schema.from_uri(test_diff1), apply_schema_to_metadata=False).build()
         metadata_db.create_all(engine)
 
-        runner = CliRunner()
-        result = runner.invoke(cli, ["diff", f"--engine-url={db_url}", test_diff2], catch_exceptions=False)
-        self.assertEqual(result.exit_code, 0)
+        run_cli(["diff", f"--engine-url={self.sqlite_url}", test_diff2])
 
     def test_diff_alembic(self) -> None:
         """Test for ``diff`` command with ``--alembic`` comparator option."""
-        test_diff1 = os.path.join(TESTDIR, "data", "test_diff1.yaml")
-        test_diff2 = os.path.join(TESTDIR, "data", "test_diff2.yaml")
-
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["diff", "--comparator", "alembic", test_diff1, test_diff2], catch_exceptions=False
-        )
-        print(result.output)
-        self.assertEqual(result.exit_code, 0)
+        test_diff1 = os.path.join(TEST_DIR, "data", "test_diff1.yaml")
+        test_diff2 = os.path.join(TEST_DIR, "data", "test_diff2.yaml")
+        run_cli(["diff", "--comparator", "alembic", test_diff1, test_diff2], print_output=True)
 
     def test_diff_error(self) -> None:
         """Test for ``diff`` command with bad arguments."""
-        test_diff1 = os.path.join(TESTDIR, "data", "test_diff1.yaml")
-        runner = CliRunner()
-        result = runner.invoke(cli, ["diff", test_diff1], catch_exceptions=False)
-        self.assertNotEqual(result.exit_code, 0)
+        test_diff1 = os.path.join(TEST_DIR, "data", "test_diff1.yaml")
+        run_cli(["diff", test_diff1], expect_error=True)
 
     def test_diff_error_on_change(self) -> None:
         """Test for ``diff`` command with ``--error-on-change`` flag."""
-        test_diff1 = os.path.join(TESTDIR, "data", "test_diff1.yaml")
-        test_diff2 = os.path.join(TESTDIR, "data", "test_diff2.yaml")
-
-        runner = CliRunner()
-        result = runner.invoke(
-            cli, ["diff", "--error-on-change", test_diff1, test_diff2], catch_exceptions=False
-        )
-        print(result.output)
-        self.assertNotEqual(result.exit_code, 0)
+        test_diff1 = os.path.join(TEST_DIR, "data", "test_diff1.yaml")
+        test_diff2 = os.path.join(TEST_DIR, "data", "test_diff2.yaml")
+        run_cli(["diff", "--error-on-change", test_diff1, test_diff2], expect_error=True, print_output=True)
 
     def test_dump_yaml(self) -> None:
         """Test for ``dump`` command with YAML output."""
-        runner = CliRunner()
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".yaml") as temp_file:
-            temp_file_name = temp_file.name
-        try:
-            result = runner.invoke(cli, ["dump", TEST_YAML, temp_file_name], catch_exceptions=False)
-            print(result.output)
-            self.assertEqual(result.exit_code, 0)
-        finally:
-            os.remove(temp_file_name)
+        with tempfile.NamedTemporaryFile(delete=True, suffix=".yaml") as temp_file:
+            run_cli(["dump", TEST_YAML, temp_file.name], print_output=True)
 
     def test_dump_json(self) -> None:
         """Test for ``dump`` command with JSON output."""
-        runner = CliRunner()
-        with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as temp_file:
-            temp_file_name = temp_file.name
-        try:
-            result = runner.invoke(cli, ["dump", TEST_YAML, temp_file_name], catch_exceptions=False)
-            print(result.output)
-            self.assertEqual(result.exit_code, 0)
-        finally:
-            os.remove(temp_file_name)
+        with tempfile.NamedTemporaryFile(delete=True, suffix=".json") as temp_file:
+            run_cli(["dump", TEST_YAML, temp_file.name], print_output=True)
 
-    def test_dump_invalid_file_extension(self) -> None:
+    def test_dump_with_invalid_file_extension_error(self) -> None:
         """Test for ``dump`` command with JSON output."""
-        runner = CliRunner()
-        result = runner.invoke(cli, ["dump", TEST_YAML, "out.bad"], catch_exceptions=False)
-        print(result.output)
-        self.assertNotEqual(result.exit_code, 0)
+        run_cli(["dump", TEST_YAML, "out.bad"], expect_error=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces a small utility module for running CLI commands in tests to avoid duplication.

All of the tests in `tests/test_cli.py` were refactoring to use the new module.

## Checklist

- [ ] Ran Jenkins
- [ ] Added a release note for user-visible changes to `docs/changes`
