### PR TITLE
Fix bug where getting the key for display raised an exception sometimes

### DIFF
--- a/python/felis/diff.py
+++ b/python/felis/diff.py
@@ -112,8 +112,10 @@ class FormattedSchemaDiff(SchemaDiff):
                 handler(self.diff[change_type])
 
     def _print_header(self, id_dict: dict[str, Any], keys: list[int | str]) -> None:
-        id = self._get_id(id_dict, keys)
-        print(f"{id} @ {self._get_key_display(keys)}")
+        # id = self._get_id(id_dict, keys)
+        # Don't display ID here for now; it is always just the schema ID.
+        print(f"{self._get_key_display(keys)}")
+        # print(f"{id} @ {self._get_key_display(keys)}")
 
     def _handle_values_changed(self, changes: dict[str, Any]) -> None:
         for key in changes:
@@ -156,13 +158,21 @@ class FormattedSchemaDiff(SchemaDiff):
 
     @staticmethod
     def _get_id(values: dict, keys: list[str | int]) -> str:
-        value = values
+        # Unused for now, pending updates to diff tool in DM-49446.
+        value: list | dict = values
         last_id = None
 
         for key in keys:
+            logger.debug(f"Processing key <{key}> with type {type(key)}")
+            logger.debug(f"Type of value: {type(value)}")
             if isinstance(value, dict) and "id" in value:
                 last_id = value["id"]
-            value = value[key]
+            elif isinstance(value, list) and isinstance(key, int):
+                if 0 <= key < len(value):
+                    value = value[key]
+                else:
+                    raise ValueError(f"Index '{key}' is out of range for list of length {len(value)}")
+                value = value[key]
 
         if isinstance(value, dict) and "id" in value:
             last_id = value["id"]


### PR DESCRIPTION
This is a temporary patch to fix the extraction of the "key" displayed for diff results. For now, this is just commented out because it was just displaying the schema ID and would fail sometimes. Further fixes and improvements to this module (basically an overhaul) will occur on DM-49446.

## Checklist

- [ ] Ran Jenkins
- [ ] Added a release note for user-visible changes to `docs/changes`
