### PR TITLE
DM-53031: Add option to instantiate TAP_SCHEMA with extensions to table columns

### DIFF
--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -286,6 +286,7 @@ def load_tap_schema(
 @cli.command("init-tap-schema", help="Initialize a standard TAP_SCHEMA database")
 @click.option("--engine-url", envvar="FELIS_ENGINE_URL", help="SQLAlchemy Engine URL", required=True)
 @click.option("--tap-schema-name", help="Name of the TAP_SCHEMA schema in the database")
+@click.option("--extensions", type=click.Path(exists=True), help="Extensions YAML file")
 @click.option(
     "--tap-tables-postfix", help="Postfix which is applied to standard TAP_SCHEMA table names", default=""
 )
@@ -297,7 +298,12 @@ def load_tap_schema(
 )
 @click.pass_context
 def init_tap_schema(
-    ctx: click.Context, engine_url: str, tap_schema_name: str, tap_tables_postfix: str, insert_metadata: bool
+    ctx: click.Context,
+    engine_url: str,
+    tap_schema_name: str,
+    extensions: str,
+    tap_tables_postfix: str,
+    insert_metadata: bool,
 ) -> None:
     """Initialize a standard TAP_SCHEMA database.
 
@@ -307,6 +313,8 @@ def init_tap_schema(
         SQLAlchemy Engine URL.
     tap_schema_name
         Name of the TAP_SCHEMA schema in the database.
+    extensions
+        Extensions YAML file.
     tap_tables_postfix
         Postfix which is applied to standard TAP_SCHEMA table names.
     insert_metadata
@@ -323,6 +331,7 @@ def init_tap_schema(
         apply_schema_to_metadata=False if engine.dialect.name == "sqlite" else True,
         schema_name=tap_schema_name,
         table_name_postfix=tap_tables_postfix,
+        extensions_path=extensions,
     )
     mgr.initialize_database(engine)
     if insert_metadata:

--- a/python/felis/config/tap_schema/tap_schema_extensions.yaml
+++ b/python/felis/config/tap_schema/tap_schema_extensions.yaml
@@ -1,0 +1,73 @@
+# TAP_SCHEMA Extensions
+# This file defines additional columns to be added to the standard TAP_SCHEMA tables
+# These are extensions beyond the IVOA TAP 1.1 specification and needed for the CADC TAP service
+
+# Extension columns for each TAP_SCHEMA table
+tables:
+  schemas:
+    - name: owner_id
+      datatype: char
+      length: 32
+      nullable: true
+      description: "Owner identifier for user-created content"
+      "@id": "#tap_schema.schemas.owner_id"
+
+    - name: read_anon
+      datatype: int
+      nullable: true
+      description: "Anonymous read permission flag (0 or 1)"
+      "@id": "#tap_schema.schemas.read_anon"
+
+    - name: read_only_group
+      datatype: char
+      length: 128
+      nullable: true
+      description: "Read-only group identifier"
+      "@id": "#tap_schema.schemas.read_only_group"
+
+    - name: read_write_group
+      datatype: char
+      length: 128
+      nullable: true
+      description: "Read-write group identifier"
+      "@id": "#tap_schema.schemas.read_write_group"
+
+    - name: api_created
+      datatype: int
+      nullable: true
+      description: "Flag indicating if schema was created via TAP service API (0 or 1)"
+      "@id": "#tap_schema.schemas.api_created"
+
+  tables:
+    - name: owner_id
+      datatype: char
+      length: 32
+      nullable: true
+      description: "Owner identifier for user-created content"
+      "@id": "#tap_schema.tables.owner_id"
+
+    - name: read_anon
+      datatype: int
+      nullable: true
+      description: "Anonymous read permission flag (0 or 1)"
+      "@id": "#tap_schema.tables.read_anon"
+
+    - name: read_only_group
+      datatype: char
+      length: 128
+      nullable: true
+      description: "Read-only group identifier"
+      "@id": "#tap_schema.tables.read_only_group"
+
+    - name: read_write_group
+      datatype: char
+      length: 128
+      nullable: true
+      description: "Read-write group identifier"
+      "@id": "#tap_schema.tables.read_write_group"
+
+    - name: api_created
+      datatype: int
+      nullable: true
+      description: "Flag indicating if table was created via TAP service API (0 or 1)"
+      "@id": "#tap_schema.tables.api_created"


### PR DESCRIPTION
## Description

As part of the plan to move TAP_SCHEMA to CloudSQL, we are going to be using felis to generate the table/schema structures and to populate the metadata as described in [SQR-107](https://sqr-107.lsst.io/). For this to work we need the additional columns that are expected for the CADC TAP service (e.g. `api_created`). These are non-standard columns, so I've gone with the approach here of introducing an extension parameter that can be used to link to additional columns that can be added to a table. 

Alternatively if we want a more simple approach and don't care about making felis specific to the CADC TAP service we could also add them directly to the existing metadata.

Or also I'm open to other/better solutions that I've not considered (not very familiar with the felis codebase so let me know if there are).


## Checklist

- [ ] Ran Jenkins
- [ ] Added a release note for user-visible changes to `docs/changes`
