### PR TITLE
DM-53031: Add option to instantiate TAP_SCHEMA with extensions to table columns

### DIFF
--- a/docs/changes/DM-53031.feature.rst
+++ b/docs/changes/DM-53031.feature.rst
@@ -1,0 +1,1 @@
+Add option to instantiate TAP_SCHEMA with extensions to table columns

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -374,6 +374,17 @@ def load_tap_schema(
 @click.option("--engine-url", envvar="FELIS_ENGINE_URL", help="SQLAlchemy Engine URL", required=True)
 @click.option("--tap-schema-name", help="Name of the TAP_SCHEMA schema in the database")
 @click.option(
+    "--extensions",
+    type=str,
+    default=None,
+    help=(
+        "Optional path to extensions YAML file (system path or resource:// URI). "
+        "If not provided, no extensions will be applied. "
+        "Example (default packaged extensions): "
+        "--extensions resource://felis/config/tap_schema/tap_schema_extensions.yaml"
+    ),
+)
+@click.option(
     "--tap-tables-postfix", help="Postfix which is applied to standard TAP_SCHEMA table names", default=""
 )
 @click.option(
@@ -384,7 +395,12 @@ def load_tap_schema(
 )
 @click.pass_context
 def init_tap_schema(
-    ctx: click.Context, engine_url: str, tap_schema_name: str, tap_tables_postfix: str, insert_metadata: bool
+    ctx: click.Context,
+    engine_url: str,
+    tap_schema_name: str,
+    extensions: str | None,
+    tap_tables_postfix: str,
+    insert_metadata: bool,
 ) -> None:
     """Initialize a standard TAP_SCHEMA database.
 
@@ -394,6 +410,8 @@ def init_tap_schema(
         SQLAlchemy Engine URL.
     tap_schema_name
         Name of the TAP_SCHEMA schema in the database.
+    extensions
+        Extensions YAML file.
     tap_tables_postfix
         Postfix which is applied to standard TAP_SCHEMA table names.
     insert_metadata
@@ -410,6 +428,7 @@ def init_tap_schema(
         apply_schema_to_metadata=False if engine.dialect.name == "sqlite" else True,
         schema_name=tap_schema_name,
         table_name_postfix=tap_tables_postfix,
+        extensions_path=extensions,
     )
     mgr.initialize_database(engine)
     if insert_metadata:

--- a/python/felis/config/tap_schema/tap_schema_extensions.yaml
+++ b/python/felis/config/tap_schema/tap_schema_extensions.yaml
@@ -1,0 +1,68 @@
+# TAP_SCHEMA Extensions
+# This file defines additional columns to be added to the standard TAP_SCHEMA tables
+# These are extensions beyond the IVOA TAP 1.1 specification and needed for the CADC TAP service
+
+# Extension columns for each TAP_SCHEMA table
+name: tap_schema_extensions
+description: Extensions to the standard TAP_SCHEMA tables
+
+tables:
+  - name: schemas
+    description: "Extensions to TAP_SCHEMA.schemas table"
+    columns:
+      - name: owner_id
+        datatype: char
+        length: 32
+        description: "Owner identifier for user-created content"
+
+      - name: read_anon
+        datatype: int
+        description: "Anonymous read permission flag (0 or 1)"
+
+      - name: read_only_group
+        datatype: char
+        length: 128
+        description: "Read-only group identifier"
+
+      - name: read_write_group
+        datatype: char
+        length: 128
+        description: "Read-write group identifier"
+
+      - name: api_created
+        datatype: int
+        description: "Flag indicating if schema was created via TAP service API (0 or 1)"
+
+  - name: tables
+    description: "Extensions to TAP_SCHEMA.tables table"
+    columns:
+      - name: owner_id
+        datatype: char
+        length: 32
+        description: "Owner identifier for user-created content"
+
+      - name: read_anon
+        datatype: int
+        description: "Anonymous read permission flag (0 or 1)"
+
+      - name: read_only_group
+        datatype: char
+        length: 128
+        description: "Read-only group identifier"
+
+      - name: read_write_group
+        datatype: char
+        length: 128
+        description: "Read-write group identifier"
+
+      - name: api_created
+        datatype: int
+        description: "Flag indicating if table was created via TAP service API (0 or 1)"
+
+  - name: columns
+    description: "Extensions to TAP_SCHEMA.columns table"
+    columns:
+      - name: column_id
+        datatype: char
+        length: 32
+        description: "Globally unique columnID for use as an XML ID attribute on the FIELD in VOTable output"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,6 +134,35 @@ class CliTestCase(unittest.TestCase):
         """
         run_cli(["init-tap-schema", "sqlite://"], expect_error=True)
 
+    def test_init_tap_schema_with_extensions(self) -> None:
+        """Test init-tap-schema command with default extensions."""
+        run_cli(
+            [
+                "init-tap-schema",
+                f"--engine-url={self.sqlite_url}",
+                "--extensions",
+                "resource://felis/config/tap_schema/tap_schema_extensions.yaml",
+            ]
+        )
+
+    def test_init_tap_schema_with_custom_extensions(self) -> None:
+        """Test init-tap-schema command with custom extensions file."""
+        extensions_file = os.path.join(self.tmpdir, "custom_extensions.yaml")
+        extensions_content = """
+    name: TAP_SCHEMA
+    tables:
+      - name: schemas
+        columns:
+          - name: field1
+            datatype: char
+            length: 64
+            description: A custom field
+    """
+        with open(extensions_file, "w") as f:
+            f.write(extensions_content)
+
+        run_cli(["init-tap-schema", f"--engine-url={self.sqlite_url}", "--extensions", extensions_file])
+
     def test_diff(self) -> None:
         """Test for ``diff`` command."""
         test_diff1 = os.path.join(TEST_DIR, "data", "test_diff1.yaml")

--- a/tests/test_tap_schema.py
+++ b/tests/test_tap_schema.py
@@ -424,5 +424,319 @@ class CompositeKeysTestCase(unittest.TestCase):
         )
 
 
+class TableManagerExtensionsTestCase(unittest.TestCase):
+    """Test the `TableManager` class with extensions."""
+
+    def setUp(self) -> None:
+        """Set up the test case."""
+        self.tmpdir = tempfile.mkdtemp(dir=TEST_DIR)
+
+        self.extensions_path = os.path.join(self.tmpdir, "test_extensions.yaml")
+        extensions_content = """
+name: test_extensions
+description: Test TAP_SCHEMA extensions
+
+tables:
+  - name: schemas
+    description: Extensions to schemas table
+    columns:
+      - name: owner_id
+        datatype: char
+        length: 32
+        nullable: true
+        description: "Owner identifier"
+      - name: read_anon
+        datatype: int
+        nullable: true
+        description: "Anon read flag"
+
+  - name: tables
+    description: Extensions to tables table
+    columns:
+      - name: api_created
+        datatype: int
+        nullable: true
+        description: "API created flag"
+"""
+        with open(self.extensions_path, "w") as f:
+            f.write(extensions_content)
+
+    def tearDown(self) -> None:
+        """Clean up temporary directory."""
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def test_extensions_applied(self) -> None:
+        mgr = TableManager(extensions_path=self.extensions_path)
+
+        schemas_table = mgr["schemas"]
+        self.assertIn("owner_id", schemas_table.c)
+        self.assertIn("read_anon", schemas_table.c)
+
+        tables_table = mgr["tables"]
+        self.assertIn("api_created", tables_table.c)
+
+    def test_extensions_column_count(self) -> None:
+        mgr_without = TableManager()
+        mgr_with = TableManager(extensions_path=self.extensions_path)
+
+        schemas_before = len(mgr_without["schemas"].c)
+        schemas_after = len(mgr_with["schemas"].c)
+        self.assertEqual(schemas_after, schemas_before + 2)
+
+        tables_before = len(mgr_without["tables"].c)
+        tables_after = len(mgr_with["tables"].c)
+        self.assertEqual(tables_after, tables_before + 1)
+
+    def test_extensions_with_data_loader(self) -> None:
+        engine = create_engine("sqlite:///:memory:")
+
+        mgr = TableManager(apply_schema_to_metadata=False, extensions_path=self.extensions_path)
+        mgr.initialize_database(engine)
+
+        with open(TEST_TAP_SCHEMA) as test_file:
+            schema = Schema.from_stream(test_file, context={"id_generation": True})
+
+        loader = DataLoader(schema, mgr, engine)
+        loader.load()
+
+        schemas_table = mgr["schemas"]
+        with engine.connect() as connection:
+            result = connection.execute(select(schemas_table))
+            row = result.fetchone()
+            self.assertIn("owner_id", row._fields)
+            self.assertIn("read_anon", row._fields)
+
+    def test_invalid_extensions_file(self) -> None:
+        invalid_path = os.path.join(self.tmpdir, "nonexistent.yaml")
+
+        with self.assertRaises(ValueError):
+            TableManager(extensions_path=invalid_path)
+
+    def test_empty_extensions(self) -> None:
+        empty_extensions_path = os.path.join(self.tmpdir, "empty_extensions.yaml")
+        with open(empty_extensions_path, "w") as f:
+            f.write("name: empty_extensions\ntables: []\n")
+
+        mgr = TableManager(extensions_path=empty_extensions_path)
+        self.assertIsNotNone(mgr["schemas"])
+
+    def test_extensions_with_null_table_extensions(self) -> None:
+        null_extensions_path = os.path.join(self.tmpdir, "null_extensions.yaml")
+        with open(null_extensions_path, "w") as f:
+            f.write("""
+name: null_extensions
+tables:
+  - name: schemas
+    columns: []
+  - name: tables
+    columns: []
+  - name: columns
+    columns:
+      - name: test_col
+        datatype: int
+""")
+
+        mgr = TableManager(extensions_path=null_extensions_path)
+
+        columns_table = mgr["columns"]
+        self.assertIn("test_col", columns_table.c)
+
+        schemas_table = mgr["schemas"]
+        self.assertNotIn("owner_id", schemas_table.c)
+
+    def test_extensions_invalid_column_missing_name(self) -> None:
+        invalid_name_path = os.path.join(self.tmpdir, "invalid_name.yaml")
+        with open(invalid_name_path, "w") as f:
+            f.write("""
+    name: invalid_name
+    tables:
+      - name: schemas
+        columns:
+          - datatype: int
+            description: "Missing name"
+          - name: some_column
+            datatype: int
+    """)
+        with self.assertRaises(KeyError):
+            TableManager(extensions_path=invalid_name_path)
+
+    def test_extensions_column_id_auto_generation(self) -> None:
+        auto_id_path = os.path.join(self.tmpdir, "auto_id.yaml")
+        with open(auto_id_path, "w") as f:
+            f.write("""
+name: auto_id
+tables:
+  - name: schemas
+    columns:
+      - name: auto_id
+        datatype: int
+        nullable: false
+        description: "Column with auto_id"
+""")
+
+        mgr = TableManager(extensions_path=auto_id_path)
+        schemas_table = mgr["schemas"]
+        self.assertIn("auto_id", schemas_table.c)
+
+    def test_extensions_column_id_preserved(self) -> None:
+        explicit_id_path = os.path.join(self.tmpdir, "explicit_id.yaml")
+        with open(explicit_id_path, "w") as f:
+            f.write("""
+name: explicit_id
+tables:
+  - name: schemas
+    columns:
+      - name: explicit_id
+        datatype: int
+        "@id": "#custom.id.path"
+""")
+
+        mgr = TableManager(extensions_path=explicit_id_path)
+        schemas_table = mgr["schemas"]
+        self.assertIn("explicit_id", schemas_table.c)
+
+    def test_extensions_multiple_tables_extended(self) -> None:
+        multi_table_path = os.path.join(self.tmpdir, "multi_table.yaml")
+        with open(multi_table_path, "w") as f:
+            f.write("""
+name: multi_table
+tables:
+  - name: schemas
+    columns:
+      - name: schema_ext1
+        datatype: int
+      - name: schema_ext2
+        datatype: int
+  - name: tables
+    columns:
+      - name: table_ext1
+        datatype: int
+      - name: table_ext2
+        datatype: double
+  - name: columns
+    columns:
+      - name: col_ext1
+        datatype: int
+  - name: keys
+    columns:
+      - name: key_ext1
+        datatype: char
+        length: 128
+""")
+
+        mgr = TableManager(extensions_path=multi_table_path)
+
+        schemas_table = mgr["schemas"]
+        self.assertIn("schema_ext1", schemas_table.c)
+        self.assertIn("schema_ext2", schemas_table.c)
+
+        tables_table = mgr["tables"]
+        self.assertIn("table_ext1", tables_table.c)
+        self.assertIn("table_ext2", tables_table.c)
+
+        columns_table = mgr["columns"]
+        self.assertIn("col_ext1", columns_table.c)
+
+        keys_table = mgr["keys"]
+        self.assertIn("key_ext1", keys_table.c)
+
+    def test_extensions_nonexistent_table_skipped(self) -> None:
+        nonexistent_table_path = os.path.join(self.tmpdir, "nonexistent_table.yaml")
+        with open(nonexistent_table_path, "w") as f:
+            f.write("""
+name: test_extensions_nonexistent_table
+tables:
+  - name: schemas
+    columns:
+      - name: valid_ext
+        datatype: int
+  - name: nonexistent_table
+    columns:
+      - name: should_be_ignored
+        datatype: int
+""")
+
+        mgr = TableManager(extensions_path=nonexistent_table_path)
+        schemas_table = mgr["schemas"]
+        self.assertIn("valid_ext", schemas_table.c)
+
+    def test_extensions_column_properties_preserved(self) -> None:
+        full_props_path = os.path.join(self.tmpdir, "full_props.yaml")
+        with open(full_props_path, "w") as f:
+            f.write("""
+name: full_props
+tables:
+  - name: schemas
+    columns:
+      - name: full_property_column
+        datatype: char
+        length: 64
+        nullable: false
+        description: "Column with all properties"
+        "@id": "#tap_schema.schemas.full_property_column"
+""")
+
+        mgr = TableManager(extensions_path=full_props_path)
+        schemas_table = mgr["schemas"]
+        self.assertIn("full_property_column", schemas_table.c)
+
+    def test_extensions_apply_schema_to_metadata_true(self) -> None:
+        mgr = TableManager(apply_schema_to_metadata=True, extensions_path=self.extensions_path)
+        schemas_table = mgr["schemas"]
+        self.assertIn("owner_id", schemas_table.c)
+
+    def test_extensions_apply_schema_to_metadata_false(self) -> None:
+        mgr = TableManager(apply_schema_to_metadata=False, extensions_path=self.extensions_path)
+
+        schemas_table = mgr["schemas"]
+        self.assertIn("owner_id", schemas_table.c)
+        self.assertIn("read_anon", schemas_table.c)
+
+    def test_extensions_with_table_name_postfix(self) -> None:
+        mgr = TableManager(
+            apply_schema_to_metadata=False, extensions_path=self.extensions_path, table_name_postfix="_custom"
+        )
+
+        schemas_table = mgr["schemas"]
+        self.assertIn("owner_id", schemas_table.c)
+
+    def test_extensions_metadata_builder_called(self) -> None:
+        mgr = TableManager(extensions_path=self.extensions_path)
+
+        self.assertIsNotNone(mgr._metadata)
+
+        table_names = list(mgr.metadata.tables.keys())
+        found_schemas = any("schemas" in name for name in table_names)
+        found_tables = any("tables" in name and "schemas" not in name for name in table_names)
+
+        self.assertTrue(found_schemas, f"No schemas table found in {table_names}")
+        self.assertTrue(found_tables, f"No tables table found in {table_names}")
+
+    def test_extensions_preserve_original_columns(self) -> None:
+        mgr = TableManager(extensions_path=self.extensions_path)
+
+        schemas_table = mgr["schemas"]
+        column_names = [col.name for col in schemas_table.columns]
+
+        self.assertIn("schema_name", column_names)
+        self.assertIn("owner_id", column_names)
+        self.assertIn("read_anon", column_names)
+
+    def test_no_extensions_path_provided(self) -> None:
+        mgr = TableManager(extensions_path=None)
+        schemas_table = mgr["schemas"]
+        self.assertNotIn("owner_id", schemas_table.c)
+
+    def test_extensions_path_empty_string(self) -> None:
+        mgr = TableManager(extensions_path="")
+        schemas_table = mgr["schemas"]
+        self.assertNotIn("owner_id", schemas_table.c)
+
+    def test_extensions_file_not_found(self) -> None:
+        nonexistent_path = os.path.join(self.tmpdir, "does_not_exist.yaml")
+        with self.assertRaises(ValueError):
+            TableManager(extensions_path=nonexistent_path)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

As part of the plan to move TAP_SCHEMA to CloudSQL, we are going to be using felis to generate the table/schema structures and to populate the metadata as described in [SQR-107](https://sqr-107.lsst.io/). For this to work we need the additional columns that are expected for the CADC TAP service (e.g. `api_created`). These are non-standard columns, so I've gone with the approach here of introducing an extension parameter that can be used to link to additional columns that can be added to a table. 

Alternatively if we want a more simple approach and don't care about making felis specific to the CADC TAP service we could also add them directly to the existing metadata.

Or also I'm open to other/better solutions that I've not considered (not very familiar with the felis codebase so let me know if there are).

## Checklist

- [x] Ran Jenkins
- [x] Added a release note for user-visible changes to `docs/changes`
