### PR TITLE
DM-53083: Add MetadataInserter to export list

### DIFF
--- a/docs/changes/DM-53083.bugfix.rst
+++ b/docs/changes/DM-53083.bugfix.rst
@@ -1,0 +1,1 @@
+Add MetadataInserter to export list

--- a/python/felis/tap_schema.py
+++ b/python/felis/tap_schema.py
@@ -43,7 +43,7 @@ from felis.metadata import MetaDataBuilder
 
 from .types import FelisType
 
-__all__ = ["DataLoader", "TableManager"]
+__all__ = ["DataLoader", "MetadataInserter", "TableManager"]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

Adds MetadataInserter to export list as plan on using this for the TAP_SCHEMA management operations in Repertoire. 

## Checklist

- [ ] Ran Jenkins
- [x] Added a release note for user-visible changes to `docs/changes`
