### PR TITLE
DM-54876: Add option to dump command for sorting output columns alphabetically

### DIFF
--- a/docs/changes/DM-54876.feature.rst
+++ b/docs/changes/DM-54876.feature.rst
@@ -1,0 +1,1 @@
+Added support to the ``dump`` command for sorting output columns alphabetically

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,9 @@ test = [
     "pytest >= 3.2"
 ]
 dev = [
-    "documenteer[guide] < 2",
+    "documenteer[guide]<2",
     "autodoc_pydantic",
+    "setuptools<82",
     "sphinx-click",
 ]
 

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -605,16 +605,25 @@ def diff(
     help="Remove any column references from resources and inline the full column definitions in the output",
     default=False,
 )
+@click.option(
+    "--sort-columns/--no-sort-columns",
+    is_flag=True,
+    help="Sort columns alphabetically by name in the output",
+    default=False,
+)
 @click.argument("files", nargs=2, type=click.Path())
 @click.pass_context
 def dump(
     ctx: click.Context,
     strip_ids: bool,
     dereference_resources: bool,
+    sort_columns: bool,
     files: list[str],
 ) -> None:
     if strip_ids:
         logger.info("Stripping IDs from the output schema")
+    if sort_columns:
+        logger.info("Sorting output columns alphabetically")
     if files[1].endswith(".json"):
         format = "json"
     elif files[1].endswith(".yaml"):
@@ -627,9 +636,10 @@ def dump(
     )
     with open(files[1], "w") as f:
         if format == "yaml":
-            schema.dump_yaml(f, strip_ids=strip_ids)
+            schema.dump_yaml(f, strip_ids=strip_ids, sort_columns=sort_columns)
         elif format == "json":
-            schema.dump_json(f, strip_ids=strip_ids)
+            schema.dump_json(f, strip_ids=strip_ids, sort_columns=sort_columns)
+    logger.info(f"Dumped {files[0]} to {files[1]}")
 
 
 if __name__ == "__main__":

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -28,6 +28,7 @@ import logging
 import sys
 from collections.abc import Sequence
 from enum import StrEnum, auto
+from operator import itemgetter
 from typing import IO, Annotated, Any, Generic, Literal, TypeAlias, TypeVar
 
 import yaml
@@ -1938,7 +1939,7 @@ class Schema(BaseObject, Generic[T]):
         yaml_data = yaml.safe_load(source)
         return Schema.model_validate(yaml_data, context=context)
 
-    def _model_dump(self, strip_ids: bool = False) -> dict[str, Any]:
+    def _model_dump(self, strip_ids: bool = False, sort_columns: bool = False) -> dict[str, Any]:
         """Dump the schema as a dictionary with some default arguments
         applied.
 
@@ -1946,6 +1947,9 @@ class Schema(BaseObject, Generic[T]):
         ----------
         strip_ids
             Whether to strip the IDs from the dumped data. Defaults to `False`.
+        sort_columns
+            Whether to sort columns alphabetically by name. Defaults to
+            `False`.
 
         Returns
         -------
@@ -1955,9 +1959,14 @@ class Schema(BaseObject, Generic[T]):
         data = self.model_dump(by_alias=True, exclude_none=True, exclude_defaults=True)
         if strip_ids:
             data = _strip_ids(data)
+        if sort_columns:
+            for table in data.get("tables", []):
+                table["columns"] = sorted(table.get("columns", []), key=itemgetter("name"))
         return data
 
-    def dump_yaml(self, stream: IO[str] = sys.stdout, strip_ids: bool = False) -> None:
+    def dump_yaml(
+        self, stream: IO[str] = sys.stdout, strip_ids: bool = False, sort_columns: bool = False
+    ) -> None:
         """Pretty print the schema as YAML.
 
         Parameters
@@ -1966,8 +1975,11 @@ class Schema(BaseObject, Generic[T]):
             The stream to write the YAML data to.
         strip_ids
             Whether to strip the IDs from the dumped data. Defaults to `False`.
+        sort_columns
+            Whether to sort columns alphabetically by name. Defaults to
+            `False`.
         """
-        data = self._model_dump(strip_ids=strip_ids)
+        data = self._model_dump(strip_ids=strip_ids, sort_columns=sort_columns)
         yaml.safe_dump(
             data,
             stream,
@@ -1975,7 +1987,9 @@ class Schema(BaseObject, Generic[T]):
             sort_keys=False,
         )
 
-    def dump_json(self, stream: IO[str] = sys.stdout, strip_ids: bool = False) -> None:
+    def dump_json(
+        self, stream: IO[str] = sys.stdout, strip_ids: bool = False, sort_columns: bool = False
+    ) -> None:
         """Pretty print the schema as JSON.
 
         Parameters
@@ -1984,8 +1998,11 @@ class Schema(BaseObject, Generic[T]):
             The stream to write the JSON data to.
         strip_ids
             Whether to strip the IDs from the dumped data. Defaults to `False`.
+        sort_columns
+            Whether to sort columns alphabetically by name. Defaults to
+            `False`.
         """
-        data = self._model_dump(strip_ids=strip_ids)
+        data = self._model_dump(strip_ids=strip_ids, sort_columns=sort_columns)
         json.dump(
             data,
             stream,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -275,6 +275,68 @@ class CliTestCase(unittest.TestCase):
         with tempfile.NamedTemporaryFile(delete=True, suffix=".json") as temp_file:
             run_cli(["dump", TEST_YAML, temp_file.name], print_output=True)
 
+    def test_dump_with_dereference_resources_and_sort_columns(self) -> None:
+        """Test dump with both --dereference-resources and --sort-columns."""
+        # Define a source schema with columns in non-alphabetical order
+        source_schema_content = """
+name: base_schema
+tables:
+- name: base_table
+  columns:
+  - name: zebra_col
+    datatype: string
+    length: 32
+  - name: alpha_col
+    datatype: int
+  - name: middle_col
+    datatype: float
+"""
+        source_path = os.path.join(self.tmpdir, "base_schema.yaml")
+        with open(source_path, "w") as f:
+            f.write(source_schema_content.strip())
+
+        # Define a referencing schema that pulls columns via columnRefs
+        ref_schema_content = f"""
+name: derived_schema
+resources:
+  base_schema:
+    uri: {source_path}
+tables:
+- name: derived_table
+  columnRefs:
+    base_schema:
+      base_table:
+        zebra_col:
+        alpha_col:
+        middle_col:
+"""
+        ref_path = os.path.join(self.tmpdir, "derived_schema.yaml")
+        with open(ref_path, "w") as f:
+            f.write(ref_schema_content.strip())
+
+        with tempfile.NamedTemporaryFile(delete=True, suffix=".yaml", dir=self.tmpdir) as temp_file:
+            run_cli(
+                [
+                    "dump",
+                    "--dereference-resources",
+                    "--sort-columns",
+                    ref_path,
+                    temp_file.name,
+                ],
+                print_output=True,
+            )
+            dumped_data = temp_file.read().decode("utf-8")
+            data = yaml.safe_load(dumped_data)
+
+            # Verify resources are dereferenced (no columnRefs remain)
+            for table in data.get("tables", []):
+                self.assertNotIn("columnRefs", table)
+                # Verify columns are present and sorted alphabetically
+                columns = table.get("columns", [])
+                self.assertGreater(len(columns), 0)
+                names = [col["name"] for col in columns]
+                self.assertEqual(names, sorted(names))
+
     def test_dump_json_with_strip_ids(self) -> None:
         """Test for ``dump`` command with JSON output."""
         with tempfile.NamedTemporaryFile(delete=True, suffix=".json") as temp_file:
@@ -286,6 +348,32 @@ class CliTestCase(unittest.TestCase):
                 self._check_strip_ids(data)
             except ValueError:
                 self.fail("Dumped YAML contains forbidden key '@id'")
+
+    @classmethod
+    def _check_columns_sorted(cls, data: dict[str, Any]) -> None:
+        """Check that columns in each table are sorted alphabetically by
+        name.
+        """
+        for table in data.get("tables", []):
+            columns = table.get("columns", [])
+            names = [col["name"] for col in columns]
+            assert names == sorted(names), f"Columns not sorted in table {table.get('name')}: {names}"
+
+    def test_dump_yaml_with_sort_columns(self) -> None:
+        """Test for ``dump`` command with YAML output and sorted columns."""
+        with tempfile.NamedTemporaryFile(delete=True, suffix=".yaml") as temp_file:
+            run_cli(["dump", "--sort-columns", TEST_YAML, temp_file.name], print_output=True)
+            dumped_data = temp_file.read().decode("utf-8")
+            data = yaml.safe_load(dumped_data)
+            self._check_columns_sorted(data)
+
+    def test_dump_json_with_sort_columns(self) -> None:
+        """Test for ``dump`` command with JSON output and sorted columns."""
+        with tempfile.NamedTemporaryFile(delete=True, suffix=".json") as temp_file:
+            run_cli(["dump", "--sort-columns", TEST_YAML, temp_file.name], print_output=True)
+            dumped_data = temp_file.read().decode("utf-8")
+            data = yaml.safe_load(dumped_data)
+            self._check_columns_sorted(data)
 
     def test_dump_with_invalid_file_extension_error(self) -> None:
         """Test for ``dump`` command with JSON output."""


### PR DESCRIPTION
https://github.com/lsst/felis/pull/180/changes/3a07dd65f1a5b96c5e436c196be3ada0b674f253 fixes the Documenteer build for now. I will convert the site to Documenteer 2.x on another PR.

## Checklist

- [x] Ran Jenkins
- [x] Added a release note for user-visible changes to `docs/changes`
