### PR TITLE
DM-54856: Add support for resolving referenced schemas automatically and convert the CLI to use resource paths and URIs

### DIFF
--- a/docs/changes/DM-54856.feature.rst
+++ b/docs/changes/DM-54856.feature.rst
@@ -1,0 +1,2 @@
+Added support for automatically resolving resources with relative URIs.
+Also converted the command line interface to use URIs rather than paths.

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -39,7 +39,7 @@ from .tap_schema import DataLoader, MetadataInserter, TableManager
 
 __all__ = ["cli"]
 
-logger = logging.getLogger("felis")
+logger = logging.getLogger(__name__)
 
 loglevel_choices = ["CRITICAL", "FATAL", "ERROR", "WARNING", "INFO", "DEBUG"]
 

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -102,8 +102,8 @@ def cli(
     ctx.obj["column_ref_index_increment"] = column_ref_index_increment
     if ctx.obj["column_ref_index_increment"] is not None:
         logger.info(
-            f"Automatic indexing of column references is enabled with increment "
-            f"{ctx.obj['column_ref_index_increment']}"
+            "Automatic indexing of column references is enabled with increment %s",
+            ctx.obj["column_ref_index_increment"],
         )
 
 
@@ -492,7 +492,7 @@ def validate(
     """
     rc = 0
     for uri in uris:
-        logger.info(f"Validating schema at '{uri}'")
+        logger.info("Validating schema at '%s'", uri)
         try:
             Schema.from_uri(
                 uri,
@@ -505,7 +505,7 @@ def validate(
                     "column_ref_index_increment": ctx.obj["column_ref_index_increment"],
                 },
             )
-            logger.info(f"Successfully validated schema at '{uri}'")
+            logger.info("Successfully validated schema at '%s'", uri)
         except ValidationError as e:
             logger.error(e)
             rc = 1
@@ -636,7 +636,7 @@ def dump(
             schema.dump_yaml(f, strip_ids=strip_ids, sort_columns=sort_columns)
         elif format == "json":
             schema.dump_json(f, strip_ids=strip_ids, sort_columns=sort_columns)
-    logger.info(f"Dumped '{uris[0]}' to '{uris[1]}'")
+    logger.info("Dumped '%s' to '%s'", uris[0], uris[1])
 
 
 if __name__ == "__main__":

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -83,11 +83,18 @@ def cli(
     """Felis command line tools"""
     ctx.ensure_object(dict)
 
-    # Configure logging (must come first)
+    # Configure logging on the felis package logger directly.
+    # Do not use basicConfig() as it is a no-op when handlers already exist
+    # (e.g., when running under pytest).
+    felis_logger = logging.getLogger("felis")
+    felis_logger.setLevel(log_level)
     if log_file:
-        logging.basicConfig(filename=log_file, level=log_level)
+        handler: logging.Handler = logging.FileHandler(log_file)
     else:
-        logging.basicConfig(level=log_level)
+        handler = logging.StreamHandler()
+    handler.setLevel(log_level)
+    handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+    felis_logger.addHandler(handler)
 
     # Configure ID generation (flag can only turn it off)
     ctx.obj["id_generation"] = id_generation

--- a/python/felis/cli.py
+++ b/python/felis/cli.py
@@ -125,7 +125,7 @@ def cli(
 )
 @click.option("--ignore-constraints", is_flag=True, help="Ignore constraints when creating tables")
 @click.option("--skip-indexes", is_flag=True, help="Skip creating indexes when building metadata")
-@click.argument("file", type=click.File())
+@click.argument("uri", type=str)
 @click.pass_context
 def create(
     ctx: click.Context,
@@ -138,7 +138,7 @@ def create(
     output_file: IO[str] | None,
     ignore_constraints: bool,
     skip_indexes: bool,
-    file: IO[str],
+    uri: str,
 ) -> None:
     """Create database objects from the Felis file.
 
@@ -162,13 +162,14 @@ def create(
         Ignore constraints when creating tables.
     skip_indexes
         Skip creating indexes when building metadata.
-    file
-        Felis file to read.
+    uri
+        URI of Felis file to read.
     """
     try:
+        schema = Schema.from_uri(uri, context={"id_generation": ctx.obj["id_generation"]})
+
         metadata = create_metadata(
-            file,
-            id_generation=ctx.obj["id_generation"],
+            schema,
             schema_name=schema_name,
             ignore_constraints=ignore_constraints,
             skip_indexes=skip_indexes,
@@ -204,13 +205,13 @@ def create(
 @cli.command("create-indexes", help="Create database indexes defined in the Felis file")
 @click.option("--engine-url", envvar="FELIS_ENGINE_URL", help="SQLAlchemy Engine URL", default="sqlite://")
 @click.option("--schema-name", help="Alternate schema name to override Felis file")
-@click.argument("file", type=click.File())
+@click.argument("uri", type=str)
 @click.pass_context
 def create_indexes(
     ctx: click.Context,
     engine_url: str,
     schema_name: str | None,
-    file: IO[str],
+    uri: str,
 ) -> None:
     """Create indexes from a Felis YAML file in a target database.
 
@@ -222,9 +223,10 @@ def create_indexes(
         Felis file to read.
     """
     try:
-        metadata = create_metadata(
-            file, id_generation=ctx.obj["id_generation"], schema_name=schema_name, engine_url=engine_url
-        )
+        schema = Schema.from_uri(uri, context={"id_generation": ctx.obj["id_generation"]})
+
+        metadata = create_metadata(schema, schema_name=schema_name, engine_url=engine_url)
+
         with create_database_context(engine_url, metadata) as db_ctx:
             db_ctx.create_indexes()
     except Exception as e:
@@ -235,13 +237,13 @@ def create_indexes(
 @cli.command("drop-indexes", help="Drop database indexes defined in the Felis file")
 @click.option("--engine-url", envvar="FELIS_ENGINE_URL", help="SQLAlchemy Engine URL", default="sqlite://")
 @click.option("--schema-name", help="Alternate schema name to override Felis file")
-@click.argument("file", type=click.File())
+@click.argument("uri", type=str)
 @click.pass_context
 def drop_indexes(
     ctx: click.Context,
     engine_url: str,
     schema_name: str | None,
-    file: IO[str],
+    uri: str,
 ) -> None:
     """Drop indexes from a Felis YAML file in a target database.
 
@@ -255,9 +257,9 @@ def drop_indexes(
         Felis file to read.
     """
     try:
-        metadata = create_metadata(
-            file, id_generation=ctx.obj["id_generation"], schema_name=schema_name, engine_url=engine_url
-        )
+        schema = Schema.from_uri(uri, context={"id_generation": ctx.obj["id_generation"]})
+
+        metadata = create_metadata(schema, schema_name=schema_name, engine_url=engine_url)
         with create_database_context(engine_url, metadata) as db:
             db.drop_indexes()
     except Exception as e:
@@ -295,7 +297,7 @@ def drop_indexes(
     help="Generate unique key_id values for keys and key_columns tables by prepending the schema name",
     default=False,
 )
-@click.argument("file", type=click.File())
+@click.argument("uri", type=str)
 @click.pass_context
 def load_tap_schema(
     ctx: click.Context,
@@ -308,7 +310,7 @@ def load_tap_schema(
     output_file: IO[str] | None,
     force_unbounded_arraysize: bool,
     unique_keys: bool,
-    file: IO[str],
+    uri: str,
 ) -> None:
     """Load TAP metadata from a Felis file.
 
@@ -345,8 +347,8 @@ def load_tap_schema(
     with create_database_context(
         engine_url, mgr.metadata, echo=echo, dry_run=dry_run, output_file=output_file
     ) as db_ctx:
-        schema = Schema.from_stream(
-            file,
+        schema = Schema.from_uri(
+            uri,
             context={
                 "id_generation": ctx.obj["id_generation"],
                 "column_ref_index_increment": ctx.obj["column_ref_index_increment"],
@@ -449,7 +451,7 @@ def init_tap_schema(
     help="Check that at least one column per table is flagged as TAP principal",
     default=False,
 )
-@click.argument("files", nargs=-1, type=click.File())
+@click.argument("uris", nargs=-1, type=str)
 @click.pass_context
 def validate(
     ctx: click.Context,
@@ -457,7 +459,7 @@ def validate(
     check_redundant_datatypes: bool,
     check_tap_table_indexes: bool,
     check_tap_principal: bool,
-    files: Iterable[IO[str]],
+    uris: Iterable[str],
 ) -> None:
     """Validate one or more felis YAML files.
 
@@ -471,8 +473,10 @@ def validate(
         Check that every table has a unique TAP table index.
     check_tap_principal
         Check that at least one column per table is flagged as TAP principal.
-    files
-        The Felis YAML files to validate.
+    uris
+        A list of URIs representing the Felis YAML files to validate. These can
+        be relative or absolute file paths or a URI with a supported scheme
+        such as ``resource://`` for package resources.
 
     Raises
     ------
@@ -487,12 +491,11 @@ def validate(
     optional validations controlled by the Pydantic context.
     """
     rc = 0
-    for file in files:
-        file_name = getattr(file, "name", None)
-        logger.info(f"Validating {file_name}")
+    for uri in uris:
+        logger.info(f"Validating schema at '{uri}'")
         try:
-            Schema.from_stream(
-                file,
+            Schema.from_uri(
+                uri,
                 context={
                     "check_description": check_description,
                     "check_redundant_datatypes": check_redundant_datatypes,
@@ -502,7 +505,7 @@ def validate(
                     "column_ref_index_increment": ctx.obj["column_ref_index_increment"],
                 },
             )
-            logger.info(f"Successfully validated {file_name}")
+            logger.info(f"Successfully validated schema at '{uri}'")
         except ValidationError as e:
             logger.error(e)
             rc = 1
@@ -533,27 +536,21 @@ def validate(
     default="deepdiff",
 )
 @click.option("-E", "--error-on-change", is_flag=True, help="Exit with error code if schemas are different")
-@click.argument("files", nargs=-1, type=click.File())
+@click.argument("uris", nargs=-1, type=str)
 @click.pass_context
 def diff(
     ctx: click.Context,
     engine_url: str | None,
     comparator: str,
     error_on_change: bool,
-    files: Iterable[IO[str]],
+    uris: Iterable[str],
 ) -> None:
-    files_list = list(files)
-    schemas = [
-        Schema.from_stream(file, context={"id_generation": ctx.obj["id_generation"]}) for file in files_list
-    ]
+    uri_list = list(uris)
+    schemas = [Schema.from_uri(uri, context={"id_generation": ctx.obj["id_generation"]}) for uri in uri_list]
     diff: SchemaDiff
     if len(schemas) == 2:
         if comparator == "alembic":
-            # Reset file stream to beginning before re-reading
-            files_list[0].seek(0)
-            metadata = create_metadata(
-                files_list[0], id_generation=ctx.obj["id_generation"], engine_url=engine_url
-            )
+            metadata = create_metadata(schemas[0], engine_url=engine_url)
             with create_database_context(
                 engine_url if engine_url else "sqlite:///:memory:", metadata
             ) as db_ctx:
@@ -611,35 +608,35 @@ def diff(
     help="Sort columns alphabetically by name in the output",
     default=False,
 )
-@click.argument("files", nargs=2, type=click.Path())
+@click.argument("uris", nargs=2, type=str)
 @click.pass_context
 def dump(
     ctx: click.Context,
     strip_ids: bool,
     dereference_resources: bool,
     sort_columns: bool,
-    files: list[str],
+    uris: list[str],
 ) -> None:
     if strip_ids:
         logger.info("Stripping IDs from the output schema")
     if sort_columns:
         logger.info("Sorting output columns alphabetically")
-    if files[1].endswith(".json"):
+    if uris[1].endswith(".json"):
         format = "json"
-    elif files[1].endswith(".yaml"):
+    elif uris[1].endswith(".yaml"):
         format = "yaml"
     else:
         raise click.ClickException("Output file must have a .json or .yaml extension")
     schema = Schema.from_uri(
-        files[0],
+        uris[0],
         context={"id_generation": ctx.obj["id_generation"], "dereference_resources": dereference_resources},
     )
-    with open(files[1], "w") as f:
+    with open(uris[1], "w") as f:
         if format == "yaml":
             schema.dump_yaml(f, strip_ids=strip_ids, sort_columns=sort_columns)
         elif format == "json":
             schema.dump_json(f, strip_ids=strip_ids, sort_columns=sort_columns)
-    logger.info(f"Dumped {files[0]} to {files[1]}")
+    logger.info(f"Dumped '{uris[0]}' to '{uris[1]}'")
 
 
 if __name__ == "__main__":

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -1302,20 +1302,33 @@ class Schema(BaseObject, Generic[T]):
         else:
             context = {}
 
+        # Get the base URI for resolving relative resource paths from the
+        # validation context, if available.
         resource_path = context.pop("resource_path", None)
+        base_uri = None
+        if resource_path is not None:
+            base_uri = resource_path.parent()
 
         for resource_name, resource in self.resources.items():
             uri = resource.uri
-            if resource_path is not None:
-                uri = resource_path.parent().join(uri)
-                logger.info(
-                    f"Resolved resource URI for '{resource_name}' to '{uri}' "
-                    f"using base path '{resource_path.parent()}'"
-                )
+
+            # Apply the base URI to the resource URI, if available.
+            if base_uri is not None:
+                orig_uri = uri
+                uri = base_uri.join(uri, forceDirectory=False)
+                if uri != orig_uri:
+                    logger.debug(
+                        "Resolved relative URI '%s' for resource '%s' to '%s' using base URI '%s'",
+                        resource.uri,
+                        resource_name,
+                        uri,
+                        base_uri,
+                    )
+
             try:
                 loaded_schema = Schema.from_uri(uri, context=context)
                 self._resource_map[resource_name] = loaded_schema
-                logger.debug(f"Loaded resource '{resource_name}' from URI '{uri}'")
+                logger.debug("Loaded resource '%s' from URI '%s'", resource_name, uri)
             except Exception as e:
                 raise ValueError(f"Failed to load resource '{resource_name}' from URI '{uri}': {e}") from e
         return self
@@ -1914,7 +1927,7 @@ class Schema(BaseObject, Generic[T]):
             Raised if the schema fails validation.
         """
         try:
-            rp = ResourcePath(resource_path, forceAbsolute=False)
+            rp = ResourcePath(resource_path, forceAbsolute=False, forceDirectory=False)
             rp_data = rp.read()
         except Exception as e:
             raise ValueError(f"Error reading resource from '{resource_path}' : {e}") from e

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -347,10 +347,10 @@ class Column(BaseObject):
                 + (f" in column '{values['@id']}'" if "@id" in values else "")
             )
         elif not felis_type.is_sized and length is not None:
-            logger.warning(
-                f"The datatype '{datatype}' does not support a specified length"
-                + (f" in column '{values['@id']}'" if "@id" in values else "")
-            )
+            msg = f"The datatype '{datatype}' does not support a specified length"
+            if "@id" in values:
+                msg += f" in column '{values['@id']}'"
+            logger.warning("%s", msg)
         return values
 
     @model_validator(mode="after")
@@ -407,10 +407,14 @@ class Column(BaseObject):
                     )
                 else:
                     logger.debug(
-                        f"Type override of 'datatype: {self.datatype}' "
-                        f"with '{db_annotation}: {datatype_string}' in column '{self.id}' "
-                        f"compiled to '{datatype_obj.compile(dialect)}' and "
-                        f"'{db_datatype_obj.compile(dialect)}'"
+                        "Type override of 'datatype: %s' with '%s: %s' in column '%s' "
+                        "compiled to '%s' and '%s'",
+                        self.datatype,
+                        db_annotation,
+                        datatype_string,
+                        self.id,
+                        datatype_obj.compile(dialect),
+                        db_datatype_obj.compile(dialect),
                     )
         return self
 
@@ -466,8 +470,11 @@ class Column(BaseObject):
                     if context.get("force_unbounded_arraysize", False):
                         arraysize = "*"
                         logger.debug(
-                            f"Forced VOTable's 'arraysize' to '*' on column '{values['name']}' with datatype "
-                            + f"'{values['datatype']}' and length '{length}'"
+                            "Forced VOTable's 'arraysize' to '*' on column '%s' with datatype "
+                            "'%s' and length '%s'",
+                            values["name"],
+                            values["datatype"],
+                            length,
                         )
                     else:
                         arraysize = f"{length}*"
@@ -476,15 +483,21 @@ class Column(BaseObject):
             if arraysize is not None:
                 values["votable:arraysize"] = arraysize
                 logger.debug(
-                    f"Set default 'votable:arraysize' to '{arraysize}' on column '{values['name']}'"
-                    + f" with datatype '{values['datatype']}' and length '{values.get('length', None)}'"
+                    "Set default 'votable:arraysize' to '%s' on column '%s'"
+                    " with datatype '%s' and length '%s'",
+                    arraysize,
+                    values["name"],
+                    values["datatype"],
+                    values.get("length", None),
                 )
         else:
-            logger.debug(f"Using existing 'votable:arraysize' of '{arraysize}' on column '{values['name']}'")
+            logger.debug(
+                "Using existing 'votable:arraysize' of '%s' on column '%s'", arraysize, values["name"]
+            )
             if isinstance(values["votable:arraysize"], int):
                 logger.warning(
-                    f"Usage of an integer value for 'votable:arraysize' in column '{values['name']}' is "
-                    + "deprecated"
+                    "Usage of an integer value for 'votable:arraysize' in column '%s' is deprecated",
+                    values["name"],
                 )
                 values["votable:arraysize"] = str(arraysize)
         return values
@@ -1317,7 +1330,7 @@ class Schema(BaseObject, Generic[T]):
                 orig_uri = uri
                 uri = base_uri.join(uri, forceDirectory=False)
                 if uri != orig_uri:
-                    logger.debug(
+                    logger.info(
                         "Resolved relative URI '%s' for resource '%s' to '%s' using base URI '%s'",
                         resource.uri,
                         resource_name,
@@ -1384,7 +1397,8 @@ class Schema(BaseObject, Generic[T]):
                 if dereference_resources and len(table.column_refs) > 0:
                     # Clear column refs in table if fully dereferencing
                     logger.debug(
-                        f"Clearing columnRefs in table '{table.name}' after dereferencing resource columns"
+                        "Clearing columnRefs in table '%s' after dereferencing resource columns",
+                        table.name,
                     )
                     table.column_refs = {}
         return self
@@ -1463,23 +1477,31 @@ class Schema(BaseObject, Generic[T]):
                         column_copy.tap_column_index = current_column_index
                         current_column_index += column_ref_index_increment
                         logger.debug(
-                            f"Automatically assigned 'tap:column_index' {column_copy.tap_column_index} to "
-                            f"column '{local_column_name}' in table '{table_name}' from resource "
-                            f"'{resource_schema.name}'"
+                            "Automatically assigned 'tap:column_index' %s to "
+                            "column '%s' in table '%s' from resource '%s'",
+                            column_copy.tap_column_index,
+                            local_column_name,
+                            table_name,
+                            resource_schema.name,
                         )
                     else:
                         # Skip automatic assignment of 'tap:column_index' if it
                         # is already overridden
                         logger.debug(
-                            f"Skipping automatic assignment of 'tap:column_index' for column "
-                            f"'{local_column_name}' in table '{table_name}' from resource "
-                            f"'{resource_schema.name}' as it is already overridden to "
-                            f"{column_copy.tap_column_index}"
+                            "Skipping automatic assignment of 'tap:column_index' for column "
+                            "'%s' in table '%s' from resource '%s' as it is already overridden to %s",
+                            local_column_name,
+                            table_name,
+                            resource_schema.name,
+                            column_copy.tap_column_index,
                         )
                 table.columns.append(column_copy)
                 logger.debug(
-                    f"Dereferenced column '{local_column_name}' from table '{table_name}' "
-                    f"in resource '{resource_schema.name}' into table '{table.name}'"
+                    "Dereferenced column '%s' from table '%s' in resource '%s' into table '%s'",
+                    local_column_name,
+                    table_name,
+                    resource_schema.name,
+                    table.name,
                 )
 
     @model_validator(mode="before")
@@ -1506,37 +1528,40 @@ class Schema(BaseObject, Generic[T]):
         schema_name = values["name"]
         if "@id" not in values:
             values["@id"] = f"#{schema_name}"
-            logger.debug(f"Generated ID '{values['@id']}' for schema '{schema_name}'")
+            logger.debug("Generated ID '%s' for schema '%s'", values["@id"], schema_name)
         if "tables" in values:
             for table in values["tables"]:
                 if "@id" not in table:
                     table["@id"] = f"#{table['name']}"
-                    logger.debug(f"Generated ID '{table['@id']}' for table '{table['name']}'")
+                    logger.debug("Generated ID '%s' for table '%s'", table["@id"], table["name"])
                 if "columns" in table:
                     for column in table["columns"]:
                         if "@id" not in column:
                             column["@id"] = f"#{table['name']}.{column['name']}"
-                            logger.debug(f"Generated ID '{column['@id']}' for column '{column['name']}'")
+                            logger.debug("Generated ID '%s' for column '%s'", column["@id"], column["name"])
                 if "columnGroups" in table:
                     for column_group in table["columnGroups"]:
                         if "@id" not in column_group:
                             column_group["@id"] = f"#{table['name']}.{column_group['name']}"
                             logger.debug(
-                                f"Generated ID '{column_group['@id']}' for column group "
-                                f"'{column_group['name']}'"
+                                "Generated ID '%s' for column group '%s'",
+                                column_group["@id"],
+                                column_group["name"],
                             )
                 if "constraints" in table:
                     for constraint in table["constraints"]:
                         if "@id" not in constraint:
                             constraint["@id"] = f"#{constraint['name']}"
                             logger.debug(
-                                f"Generated ID '{constraint['@id']}' for constraint '{constraint['name']}'"
+                                "Generated ID '%s' for constraint '%s'",
+                                constraint["@id"],
+                                constraint["name"],
                             )
                 if "indexes" in table:
                     for index in table["indexes"]:
                         if "@id" not in index:
                             index["@id"] = f"#{index['name']}"
-                            logger.debug(f"Generated ID '{index['@id']}' for index '{index['name']}'")
+                            logger.debug("Generated ID '%s' for index '%s'", index["@id"], index["name"])
         return values
 
     @field_validator("tables", mode="after")

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -948,11 +948,11 @@ class Table(BaseObject):
     mysql_charset: str | None = Field(None, alias="mysql:charset")
     """MySQL charset to use for the table."""
 
-    columns: list[Column] = Field(default_factory=list)
-    """Columns in the table."""
-
     column_refs: ResourceMap = Field(default_factory=dict, alias="columnRefs")
     """Referenced columns from external resources."""
+
+    columns: list[Column] = Field(default_factory=list)
+    """Columns in the table."""
 
     column_groups: list[ColumnGroup] = Field(default_factory=list, alias="columnGroups")
     """Column groups in the table."""
@@ -1268,11 +1268,11 @@ class Schema(BaseObject, Generic[T]):
     version: SchemaVersion | str | None = None
     """The version of the schema."""
 
-    tables: Sequence[Table]
-    """The tables in the schema."""
-
     resources: dict[str, Resource] = Field(default_factory=dict)
     """External resources referenced by this schema."""
+
+    tables: Sequence[Table]
+    """The tables in the schema."""
 
     _id_map: dict[str, Any] = PrivateAttr(default_factory=dict)
     """Map of IDs to objects."""

--- a/python/felis/datamodel.py
+++ b/python/felis/datamodel.py
@@ -1302,8 +1302,16 @@ class Schema(BaseObject, Generic[T]):
         else:
             context = {}
 
+        resource_path = context.pop("resource_path", None)
+
         for resource_name, resource in self.resources.items():
             uri = resource.uri
+            if resource_path is not None:
+                uri = resource_path.parent().join(uri)
+                logger.info(
+                    f"Resolved resource URI for '{resource_name}' to '{uri}' "
+                    f"using base path '{resource_path.parent()}'"
+                )
             try:
                 loaded_schema = Schema.from_uri(uri, context=context)
                 self._resource_map[resource_name] = loaded_schema
@@ -1906,10 +1914,14 @@ class Schema(BaseObject, Generic[T]):
             Raised if the schema fails validation.
         """
         try:
-            rp_stream = ResourcePath(resource_path).read()
+            rp = ResourcePath(resource_path, forceAbsolute=False)
+            rp_data = rp.read()
         except Exception as e:
             raise ValueError(f"Error reading resource from '{resource_path}' : {e}") from e
-        yaml_data = yaml.safe_load(rp_stream)
+        yaml_data = yaml.safe_load(rp_data)
+        context = dict(context)
+        # Append the resource path to the context for resolving resource URLs.
+        context["resource_path"] = rp
         return Schema.model_validate(yaml_data, context=context)
 
     @classmethod

--- a/python/felis/db/database_context.py
+++ b/python/felis/db/database_context.py
@@ -65,7 +65,7 @@ __all__ = [
     "create_database_context",
 ]
 
-logger = logging.getLogger("felis")
+logger = logging.getLogger(__name__)
 
 SQLStatement = str | Executable | TextClause
 

--- a/python/felis/db/database_context.py
+++ b/python/felis/db/database_context.py
@@ -260,14 +260,14 @@ class DatabaseContext(AbstractContextManager):
         ...
 
     @abstractmethod
-    def execute(self, statement: SQLStatement, parameters: dict[str, Any] | None = None) -> Result:
+    def execute(self, statement: SQLStatement, params: dict[str, Any] | None = None) -> Result:
         """Execute a SQL statement and return the result.
 
         Parameters
         ----------
         statement
             The SQL statement to execute.
-        parameters
+        params
             Optional parameters to use for the SQL statement.
 
         Returns
@@ -393,13 +393,13 @@ class _BaseContext(DatabaseContext):
         with self.engine.connect() as connection:
             yield connection
 
-    def execute(self, statement: SQLStatement, parameters: dict[str, Any] | None = None) -> Result:
+    def execute(self, statement: SQLStatement, params: dict[str, Any] | None = None) -> Result:
         statement = _normalize_statement(statement)
         try:
             with self.connect() as conn:
                 with conn.begin():
-                    if parameters:
-                        result = conn.execute(statement, parameters)
+                    if params:
+                        result = conn.execute(statement, params)
                     else:
                         result = conn.execute(statement)
                     return result
@@ -835,10 +835,10 @@ class MockContext(DatabaseContext):
         # Mock connection can't drop indexes.
         pass
 
-    def execute(self, statement: SQLStatement, parameters: dict[str, Any] | None = None) -> Result:
+    def execute(self, statement: SQLStatement, params: dict[str, Any] | None = None) -> Result:
         statement = _normalize_statement(statement)
-        if parameters:
-            return self._connection.connect().execute(statement, parameters)
+        if params:
+            return self._connection.connect().execute(statement, params)
         else:
             return self._connection.connect().execute(statement)
 

--- a/python/felis/db/database_context.py
+++ b/python/felis/db/database_context.py
@@ -267,6 +267,8 @@ class DatabaseContext(AbstractContextManager):
         ----------
         statement
             The SQL statement to execute.
+        parameters
+            Optional parameters to use for the SQL statement.
 
         Returns
         -------
@@ -436,23 +438,24 @@ class _BaseContext(DatabaseContext):
                         for index in table.indexes:
                             if index.name is None:
                                 # Anonymous indexes can't be checked by name
-                                logger.warning(f"Skipping anonymous index on table '{table.name}'")
+                                logger.warning("Skipping anonymous index on table '%s'", table.name)
                                 continue
 
                             if action == "create":
                                 if index.name in existing_indexes:
                                     logger.warning(
-                                        f"Skipping creation of index '{index.name}' which already exists"
+                                        "Skipping creation of index '%s' which already exists",
+                                        index.name,
                                     )
                                     continue
                                 index.create(bind=conn, checkfirst=False)  # We already checked
-                                logger.info(f"Created index '{index.name}'")
+                                logger.info("Created index '%s'", index.name)
                             elif action == "drop":
                                 if index.name not in existing_indexes:
-                                    logger.warning(f"Skipping index '{index.name}' which does not exist")
+                                    logger.warning("Skipping index '%s' which does not exist", index.name)
                                     continue
                                 index.drop(bind=conn, checkfirst=False)  # We already checked
-                                logger.info(f"Dropped index '{index.name}'")
+                                logger.info("Dropped index '%s'", index.name)
                             else:
                                 raise ValueError(f"Invalid action '{action}'. Must be 'create' or 'drop'.")
                 except SQLAlchemyError as e:
@@ -677,7 +680,7 @@ class PostgreSQLContext(_BaseContext):
     def initialize(self) -> None:
         schema_name = self._required_schema_name()
         try:
-            logger.debug(f"Checking if PG schema exists: {schema_name}")
+            logger.debug("Checking if PG schema exists: %s", schema_name)
             result = self.execute(
                 """
                 SELECT schema_name
@@ -688,7 +691,7 @@ class PostgreSQLContext(_BaseContext):
             )
             if result.fetchone():
                 return
-            logger.debug(f"Creating PG schema: {schema_name}")
+            logger.debug("Creating PG schema: %s", schema_name)
             self.execute(CreateSchema(schema_name))
         except SQLAlchemyError as e:
             raise DatabaseContextError(f"Error initializing Postgres schema: {e}") from e
@@ -696,7 +699,7 @@ class PostgreSQLContext(_BaseContext):
     def drop(self) -> None:
         schema_name = self._required_schema_name()
         try:
-            logger.debug(f"Dropping PostgreSQL schema if exists: {schema_name}")
+            logger.debug("Dropping PostgreSQL schema if exists: %s", schema_name)
             self.execute(DropSchema(schema_name, if_exists=True, cascade=True))
         except SQLAlchemyError as e:
             raise DatabaseContextError(f"Error dropping Postgres database: {e}") from e
@@ -724,11 +727,11 @@ class MySQLContext(_BaseContext):
         # distinct schema concept, unlike Postgres.
         schema_name = self._required_schema_name()
         try:
-            logger.debug(f"Checking if MySQL database exists: {schema_name}")
+            logger.debug("Checking if MySQL database exists: %s", schema_name)
             result = self.execute("SHOW DATABASES LIKE :schema_name", {"schema_name": schema_name})
             if result.fetchone():
                 return
-            logger.debug(f"Creating MySQL database: {schema_name}")
+            logger.debug("Creating MySQL database: %s", schema_name)
             from sqlalchemy import DDL
 
             create_stmt = DDL(f"CREATE DATABASE {quoted_name(schema_name, quote=True)}")
@@ -739,7 +742,7 @@ class MySQLContext(_BaseContext):
     def drop(self) -> None:
         schema_name = self._required_schema_name()
         try:
-            logger.debug(f"Dropping MySQL database if exists: {schema_name}")
+            logger.debug("Dropping MySQL database if exists: %s", schema_name)
             from sqlalchemy import DDL
 
             drop_stmt = DDL(f"DROP DATABASE IF EXISTS {quoted_name(schema_name, quote=True)}")

--- a/python/felis/diff.py
+++ b/python/felis/diff.py
@@ -163,8 +163,8 @@ class FormattedSchemaDiff(SchemaDiff):
         last_id = None
 
         for key in keys:
-            logger.debug(f"Processing key <{key}> with type {type(key)}")
-            logger.debug(f"Type of value: {type(value)}")
+            logger.debug("Processing key <%s> with type %s", key, type(key))
+            logger.debug("Type of value: %s", type(value))
             if isinstance(value, dict) and "id" in value:
                 last_id = value["id"]
             elif isinstance(value, list) and isinstance(key, int):

--- a/python/felis/metadata.py
+++ b/python/felis/metadata.py
@@ -283,7 +283,7 @@ class MetaDataBuilder:
                 server_default = text(server_default)
 
         if server_default is not None:
-            logger.debug(f"Column '{id}' has default value: {server_default}")
+            logger.debug("Column '%s' has default value: %s", id, server_default)
 
         column: Column = Column(
             name,
@@ -430,7 +430,7 @@ def create_metadata(
         The SQLAlchemy metadata object with proper schema handling.
     """
     if schema_name:
-        logger.info(f"Overriding schema name with: {schema_name}")
+        logger.info("Overriding schema name with: %s", schema_name)
         schema.name = schema_name
 
     # Determine if we need SQLite-specific handling

--- a/python/felis/metadata.py
+++ b/python/felis/metadata.py
@@ -24,7 +24,7 @@
 from __future__ import annotations
 
 import logging
-from typing import IO, Any, Literal
+from typing import Any, Literal
 
 from lsst.utils.iteration import ensure_iterable
 from sqlalchemy import (
@@ -403,24 +403,20 @@ class MetaDataBuilder:
 
 
 def create_metadata(
-    felis_file: IO[str],
+    schema: Schema,
     schema_name: str | None = None,
-    id_generation: bool = True,
     ignore_constraints: bool = False,
     skip_indexes: bool = False,
     engine_url: str | None = None,
 ) -> MetaData:
-    """Create SQLAlchemy metadata from a Felis schema file.
+    """Create SQLAlchemy metadata from a Felis schema object.
 
     Parameters
     ----------
-    felis_file
-        The Felis schema file to read.
+    schema
+        The Felis schema object.
     schema_name
         Optional schema name to override the one in the file.
-    id_generation
-        Whether to generate IDs for all objects in the schema that do not have
-        them.
     ignore_constraints
         Whether to ignore constraints when building metadata.
     skip_indexes
@@ -433,7 +429,6 @@ def create_metadata(
     MetaData
         The SQLAlchemy metadata object with proper schema handling.
     """
-    schema = Schema.from_stream(felis_file, context={"id_generation": id_generation})
     if schema_name:
         logger.info(f"Overriding schema name with: {schema_name}")
         schema.name = schema_name

--- a/python/felis/tap_schema.py
+++ b/python/felis/tap_schema.py
@@ -318,7 +318,7 @@ class TableManager:
             )
             for table_name in TableManager.get_table_names_std()
         }
-        logger.debug(f"Created TAP_SCHEMA table map: {self._table_map}")
+        logger.debug("Created TAP_SCHEMA table map: %s", self._table_map)
 
     def _check_tables(self) -> None:
         """Check that there is a valid mapping to each standard table.

--- a/python/felis/tests/run_cli.py
+++ b/python/felis/tests/run_cli.py
@@ -32,7 +32,7 @@ __all__ = ["run_cli"]
 
 def run_cli(
     cmd: list[str],
-    log_level: int = logging.WARNING,
+    log_level: int = logging.DEBUG,
     expect_error: bool = False,
     print_cmd: bool = False,
     print_output: bool = False,
@@ -45,7 +45,8 @@ def run_cli(
     cmd : list[str]
         The command to run.
     log_level : int
-        The logging level to use, by default logging.WARNING.
+        The logging level to use, by default logging.DEBUG so that all messages
+        are emitted.
     expect_error : bool
         Whether to expect an error, by default False.
     print_cmd : bool

--- a/python/felis/tests/run_cli.py
+++ b/python/felis/tests/run_cli.py
@@ -33,7 +33,6 @@ __all__ = ["run_cli"]
 def run_cli(
     cmd: list[str],
     log_level: int = logging.WARNING,
-    catch_exceptions: bool = False,
     expect_error: bool = False,
     print_cmd: bool = False,
     print_output: bool = False,
@@ -47,8 +46,6 @@ def run_cli(
         The command to run.
     log_level : int
         The logging level to use, by default logging.WARNING.
-    catch_exceptions : bool
-        Whether to catch exceptions, by default False.
     expect_error : bool
         Whether to expect an error, by default False.
     print_cmd : bool
@@ -69,11 +66,11 @@ def run_cli(
     result = runner.invoke(
         cli,
         full_cmd,
-        catch_exceptions=catch_exceptions,
+        catch_exceptions=expect_error,
     )
     if print_output:
         print(result.output)
     if expect_error:
         assert result.exit_code != 0
     else:
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,11 +48,6 @@ class CliTestCase(unittest.TestCase):
         self.sqlite_url = f"sqlite:///{self.tmpdir}/db.sqlite3"
         print(f"Using temporary directory: {self.tmpdir}")
 
-        # Clear any existing logging handlers to ensure fresh configuration for
-        # each test
-        for handler in logging.root.handlers[:]:
-            logging.root.removeHandler(handler)
-
     def tearDown(self) -> None:
         """Clean up temporary directory."""
         shutil.rmtree(self.tmpdir, ignore_errors=True)

--- a/tests/test_datamodel.py
+++ b/tests/test_datamodel.py
@@ -1339,7 +1339,7 @@ tables:
         with self.assertRaises(ValueError) as cm:
             Schema.from_uri(error_ref_path, context={"id_generation": True})
         self.assertIn(
-            "Failed to load resource 'bad_resource' from URI '/nonexistent/path/to/schema.yaml'",
+            "Failed to load resource 'bad_resource' from URI 'file:///nonexistent/path/to/schema.yaml'",
             str(cm.exception),
         )
 
@@ -1551,6 +1551,141 @@ tables:
                 self.assertEqual(column.tap_column_index, 20)
             else:
                 self.fail(f"Unexpected column name: {column.name}")
+
+    def test_from_uri_with_relative_resource_uri(self) -> None:
+        """Test that from_uri resolves a relative resource URI using the
+        schema's resource_path context.
+        """
+        source_content = """
+name: source_schema
+tables:
+- name: source_table
+  columns:
+  - name: test_column
+    datatype: int
+"""
+        source_path = os.path.join(self.temp_dir, "source_schema.yaml")
+        with open(source_path, "w") as f:
+            f.write(source_content.strip())
+
+        # Write referencing schema using a relative URI.
+        ref_content = """
+name: ref_schema
+resources:
+  source_schema:
+    uri: source_schema.yaml
+tables:
+- name: ref_table
+  columnRefs:
+    source_schema:
+      source_table:
+        test_column:
+"""
+        ref_path = os.path.join(self.temp_dir, "ref_schema.yaml")
+        with open(ref_path, "w") as f:
+            f.write(ref_content.strip())
+
+        base_rp = ResourcePath(ref_path)
+        resolved_rp = base_rp.parent().join("source_schema.yaml")
+        self.assertEqual(resolved_rp.ospath, source_path)
+
+        # Load via from_uri; the relative resource URI should be resolved
+        # against the referencing schema's directory.
+        schema = Schema.from_uri(ref_path, context={"id_generation": True})
+
+        # Verify the resource was found and loaded without errors
+        self.assertIn("source_schema", schema._resource_map)
+
+    def test_from_uri_with_absolute_resource_uri(self) -> None:
+        """Test that from_uri works with an absolute resource URI."""
+        source_content = """
+name: source_schema
+tables:
+- name: source_table
+  columns:
+  - name: test_column
+    datatype: int
+"""
+        source_path = os.path.join(self.temp_dir, "source_schema.yaml")
+        with open(source_path, "w") as f:
+            f.write(source_content.strip())
+
+        # Write referencing schema that uses an absolute URI for the resource
+        ref_content = f"""
+name: ref_schema
+resources:
+  source_schema:
+    uri: {source_path}
+tables:
+- name: ref_table
+  columnRefs:
+    source_schema:
+      source_table:
+        test_column:
+"""
+        ref_path = os.path.join(self.temp_dir, "ref_schema.yaml")
+        with open(ref_path, "w") as f:
+            f.write(ref_content.strip())
+
+        # Verify the expected resolved path from joining absolute URI.
+        from lsst.resources import ResourcePath
+
+        base_rp = ResourcePath(ref_path)
+        resolved_rp = base_rp.join(source_path)
+        self.assertEqual(resolved_rp.ospath, source_path)
+
+        # Load via from_uri with an absolute resource URI.
+        schema = Schema.from_uri(ref_path, context={"id_generation": True})
+
+        # Verify the resource was found and loaded without errors.
+        self.assertIn("source_schema", schema._resource_map)
+
+    def test_absolute_resource_uri_ignores_ref_schema_directory(self) -> None:
+        """Test that an absolute resource URI is not resolved relative to
+        the referencing schema's directory.
+        """
+        # Put the source schema in its own subdirectory.
+        source_dir = os.path.join(self.temp_dir, "source_dir")
+        os.makedirs(source_dir)
+
+        source_content = """
+name: source_schema
+tables:
+- name: source_table
+  columns:
+  - name: test_column
+    datatype: int
+"""
+        source_path = os.path.join(source_dir, "source_schema.yaml")
+        with open(source_path, "w") as f:
+            f.write(source_content.strip())
+
+        # Put the referencing schema in a different subdirectory.
+        ref_dir = os.path.join(self.temp_dir, "ref_dir")
+        os.makedirs(ref_dir)
+
+        ref_content = f"""
+name: ref_schema
+resources:
+  source_schema:
+    uri: {source_path}
+tables:
+- name: ref_table
+  columnRefs:
+    source_schema:
+      source_table:
+        test_column:
+"""
+        ref_path = os.path.join(ref_dir, "ref_schema.yaml")
+        with open(ref_path, "w") as f:
+            f.write(ref_content.strip())
+
+        # Load via from_uri. The absolute URI should resolve directly,
+        # ignoring the referencing schema's directory.
+        schema = Schema.from_uri(ref_path, context={"id_generation": True})
+
+        # Verify the resource was found and loaded without errors.
+        self.assertIn("source_schema", schema._resource_map)
 
 
 class ColumnOverridesTestCase(unittest.TestCase):


### PR DESCRIPTION
This PR updates the resolution of relative resource URIs such as `uri: drp_base.yaml` to use the schema's base path. For instance, if the schema was loaded from `file:///tmp/yml/schema.yaml`, then for a resource this would resolve to `file:///tmp/tmp/drp_base.yaml`. Referenced URIs with absolute paths will not trigger this behavior.

The command line interface was also converted to use URIs, because the previous behavior using file streams did not provide URIs for this resolution.

## Checklist

- [x] Ran Jenkins
- [x] Added a release note for user-visible changes to `docs/changes`
